### PR TITLE
fix: IC-2 - refactored addon info parsing

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,19 +2,9 @@ use std::fs::read_to_string;
 use std::io::{Error};
 use yaml_rust::{Yaml, YamlLoader};
 
-pub struct ConnectionData {
-    pub username: String,
-    pub password: String,
-    pub realm_name: String,
-}
+mod types;
 
-pub struct BotChat {
-    pub greet: Vec<String>,
-    pub agree: Vec<String>,
-    pub disagree: Vec<String>,
-    pub follow_invite: Vec<String>,
-    pub stop: Vec<String>,
-}
+use crate::config::types::{AddonInfo, BotChat, ConnectionData};
 
 pub struct ConfigParams<'a> {
     pub host: &'a str,
@@ -22,7 +12,7 @@ pub struct ConfigParams<'a> {
 
 pub struct Config {
     pub connection_data: ConnectionData,
-    pub addons: Yaml,
+    pub addons: Vec<AddonInfo>,
     pub bot_chat: BotChat,
 }
 
@@ -32,12 +22,12 @@ impl Config {
         let docs = YamlLoader::load_from_str(&data).unwrap();
 
         let connection_data = Self::parse_connection_data(&docs[0]["connection_data"][params.host]);
-        let addons = &docs[0]["addons"];
+        let addons = Self::parse_addons(&docs[0]["addons"]);
         let bot_chat = Self::parse_chat_config(&docs[0]["bot_chat"]);
 
         Ok(Self {
             connection_data,
-            addons: addons.to_owned(),
+            addons,
             bot_chat,
         })
     }
@@ -48,6 +38,21 @@ impl Config {
             password: config["password"].as_str().unwrap().to_string().to_uppercase(),
             realm_name: config["realm_name"].as_str().unwrap().to_string(),
         }
+    }
+
+    fn parse_addons(config: &Yaml) -> Vec<AddonInfo> {
+        let mut addons: Vec<AddonInfo> = Vec::new();
+
+        for addon in config.as_vec().unwrap() {
+            addons.push(AddonInfo {
+                name: addon["name"].as_str().unwrap().to_string(),
+                flags: addon["flags"].as_i64().unwrap() as u8,
+                modulus_crc: addon["modulus_crc"].as_i64().unwrap() as u32,
+                urlcrc_crc: addon["urlcrc_crc"].as_i64().unwrap() as u32,
+            });
+        }
+
+        addons
     }
 
     fn parse_chat_config(config: &Yaml) -> BotChat {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,0 +1,20 @@
+pub struct ConnectionData {
+    pub username: String,
+    pub password: String,
+    pub realm_name: String,
+}
+
+pub struct AddonInfo {
+    pub name: String,
+    pub flags: u8,
+    pub modulus_crc: u32,
+    pub urlcrc_crc: u32,
+}
+
+pub struct BotChat {
+    pub greet: Vec<String>,
+    pub agree: Vec<String>,
+    pub disagree: Vec<String>,
+    pub follow_invite: Vec<String>,
+    pub stop: Vec<String>,
+}


### PR DESCRIPTION
From this commit addons parsed on config loading level, so on handler level we working just with `AddonInfo` struct, not with `Yaml` struct.