### PR TITLE
feat: IC-27 - added handling of git hooks

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -11,12 +11,12 @@ name: rust-clippy analyze
 
 on:
   push:
-    branches: [ "primary" ]
+    branches: [ "primary", "dev" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "primary" ]
+    branches: [ "primary", "dev" ]
   schedule:
-    - cron: '34 0 * * 0'
+    - cron: '0 0 * * *'
 
 jobs:
   rust-clippy-analyze:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "primary" ]
+    branches: [ "primary", "dev" ]
   pull_request:
-    branches: [ "primary" ]
+    branches: [ "primary", "dev" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,5 @@
+[hooks]
+pre-commit = "cargo test"
+
+[logging]
+verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ yaml-rust = "0.4.5"
 tokio = { version = "1", features = ["sync", "net", "io-util", "macros", "time", "rt-multi-thread"] }
 bitflags = "1.3.2"
 futures = "0.3.21"
+
+[dev-dependencies]
+rusty-hook = "0.11.2"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -335,7 +335,7 @@ mod tests {
 
     const HOST: &str = "127.0.0.1";
     // https://users.rust-lang.org/t/async-tests-sometimes-fails/78451
-    // port should be zero to avoid race condition
+    // port should be zero to avoid race condition (in case of running in parallel)
     // so OS will create connection with random port
     const PORT: u16 = 0;
     const WRONG_HOST: &str = "1.2.3.4";


### PR DESCRIPTION
Within this PR I added `rusty-hook` crate for handling git hooks. Also added extra checks for **dev** branch and re-scheduled clippy check for **primary** and **dev** branches.