### PR TITLE
feat: IC-39 - added support for modes

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -189,18 +189,24 @@ impl Client {
         let income_message_pipe = Arc::clone(&self._income_message_pipe);
         let pipe = self._outcome_message_pipe.lock().unwrap();
         let dialog_outcome = pipe.dialog_outcome.clone();
+        let flag_outcome = pipe.flag_outcome.clone();
+        let client_flags = Arc::clone(&self.client_flags);
 
         tokio::task::spawn_blocking(move || {
             let mut ui = UI::new(
                 CrosstermBackend::new(std::io::stdout()),
                 UIOutputOptions {
                     dialog_outcome,
+                    flag_outcome,
                 },
             );
 
             loop {
+                let client_flags = &client_flags.lock().unwrap().clone();
+
                 ui.render(UIRenderOptions {
                     message: income_message_pipe.lock().unwrap().recv(),
+                    client_flags,
                 });
             }
         })

--- a/src/ipc/pipe/flag.rs
+++ b/src/ipc/pipe/flag.rs
@@ -1,0 +1,21 @@
+use std::sync::mpsc::Sender;
+
+use crate::ipc::pipe::types::OutcomeMessageType;
+use crate::ui::types::UIModeFlags;
+
+#[derive(Clone, Debug)]
+pub struct FlagOutcome {
+    _sender: Sender<OutcomeMessageType>,
+}
+
+impl FlagOutcome {
+    pub fn new(sender: Sender<OutcomeMessageType>) -> Self {
+        Self {
+            _sender: sender,
+        }
+    }
+
+    pub fn send_toggle_flag(&mut self, flag: UIModeFlags) {
+        self._sender.send(OutcomeMessageType::SetUIMode(flag)).unwrap();
+    }
+}

--- a/src/ipc/pipe/mod.rs
+++ b/src/ipc/pipe/mod.rs
@@ -1,11 +1,13 @@
 use std::sync::mpsc::{self, Receiver, RecvError};
 
 pub mod dialog;
+pub mod flag;
 pub mod key_event;
 pub mod message;
 pub mod types;
 
 use crate::ipc::pipe::dialog::{DialogIncome, DialogOutcome};
+use crate::ipc::pipe::flag::FlagOutcome;
 use crate::ipc::pipe::key_event::KeyEventIncome;
 use crate::ipc::pipe::message::MessageIncome;
 use crate::ipc::pipe::types::{IncomeMessageType, OutcomeMessageType};
@@ -38,6 +40,7 @@ impl IncomeMessagePipe {
 
 pub struct OutcomeMessagePipe {
     pub dialog_outcome: DialogOutcome,
+    pub flag_outcome: FlagOutcome,
     _receiver: Receiver<OutcomeMessageType>,
 }
 
@@ -47,6 +50,7 @@ impl OutcomeMessagePipe {
 
         Self {
             dialog_outcome: DialogOutcome::new(output_tx.clone()),
+            flag_outcome: FlagOutcome::new(output_tx.clone()),
             _receiver: output_rx,
         }
     }

--- a/src/ipc/pipe/types.rs
+++ b/src/ipc/pipe/types.rs
@@ -1,6 +1,7 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::client::{Character, Realm};
+use crate::ui::types::UIModeFlags;
 
 // messages from client to UI
 #[derive(Debug)]
@@ -15,6 +16,7 @@ pub enum IncomeMessageType {
 pub enum OutcomeMessageType {
     RealmSelected(Realm),
     CharacterSelected(Character),
+    SetUIMode(UIModeFlags),
 }
 
 #[derive(Debug)]

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -3,12 +3,13 @@ use tui::Frame;
 use tui::layout::Rect;
 
 use crate::types::{HandlerInput, ProcessorResult};
+use crate::ui::types::UIComponentOptions;
 
 pub trait Processor {
     fn process_input(input: &mut HandlerInput) -> ProcessorResult;
 }
 
 pub trait UIComponent {
-    fn new() -> Self where Self: Sized;
+    fn new(options: UIComponentOptions) -> Self where Self: Sized;
     fn render<B: Backend>(&mut self, frame: &mut Frame<B>, rect: Rect);
 }

--- a/src/ui/debug_panel.rs
+++ b/src/ui/debug_panel.rs
@@ -8,16 +8,23 @@ use tui::widgets::{Block, Borders, BorderType, Paragraph, Wrap};
 use crate::ipc::pipe::types::LoggerOutput;
 use crate::types::traits::UIComponent;
 use crate::ui::MARGIN;
+use crate::ui::types::{UIComponentOptions};
 
 const PANEL_TITLE: &str = "DEBUG";
 
 pub struct DebugPanel<'a> {
     items: Vec<Spans<'a>>,
+    debug_mode: bool,
 }
 
 impl<'a> DebugPanel<'a> {
+    pub fn set_mode(&mut self, debug_mode: bool) -> &mut Self {
+        self.debug_mode = debug_mode;
+        self
+    }
+
     pub fn add_item(&mut self, output: LoggerOutput) -> &mut Self {
-        let message = Self::generate_message(output);
+        let message = self.generate_message(output);
 
         if !message.content.is_empty() {
             self.items.push(Spans::from(message));
@@ -26,9 +33,9 @@ impl<'a> DebugPanel<'a> {
         self
     }
 
-    fn generate_message(output: LoggerOutput) -> Span<'a> {
+    fn generate_message(&mut self, output: LoggerOutput) -> Span<'a> {
         match output {
-            LoggerOutput::Debug(data) if !data.is_empty() => Span::styled(
+            LoggerOutput::Debug(data) if !data.is_empty() && self.debug_mode => Span::styled(
                 format!("[DEBUG]: {}\n", data), Style::default().fg(Color::DarkGray)
             ),
             LoggerOutput::Error(data) if !data.is_empty() => Span::styled(
@@ -49,9 +56,10 @@ impl<'a> DebugPanel<'a> {
 }
 
 impl<'a> UIComponent for DebugPanel<'a> {
-    fn new() -> Self {
+    fn new(_: UIComponentOptions) -> Self {
         Self {
             items: vec![],
+            debug_mode: false,
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ use tui::Terminal;
 
 mod characters_modal;
 mod debug_panel;
+mod mode_panel;
 mod realm_modal;
 pub mod types;
 mod title;
@@ -30,27 +31,38 @@ mod title;
 use crate::client::Player;
 use crate::client::types::ClientFlags;
 use crate::ipc::pipe::dialog::DialogOutcome;
+use crate::ipc::pipe::flag::FlagOutcome;
 use crate::ipc::pipe::key_event::KeyEventIncome;
 use crate::ipc::pipe::types::{IncomeMessageType, OutcomeMessageType};
 use crate::ipc::session::Session;
 use crate::types::traits::UIComponent;
 use crate::ui::characters_modal::CharactersModal;
 use crate::ui::debug_panel::DebugPanel;
+use crate::ui::mode_panel::ModePanel;
 use crate::ui::realm_modal::RealmModal;
 use crate::ui::title::Title;
-use crate::ui::types::{UIOutputOptions, UIRenderOptions, UIStateFlags};
+use crate::ui::types::{
+    UIComponentOptions,
+    UIModeFlags,
+    UIOutputOptions,
+    UIRenderOptions,
+    UIStateFlags
+};
 
 pub const MARGIN: u16 = 1;
 
 pub struct UI<'a, B: Backend> {
-    _terminal: Terminal<B>,
-    _state_flags: UIStateFlags,
+    state_flags: UIStateFlags,
 
-    _debug_panel: DebugPanel<'a>,
-    _title: Title,
-    _characters_modal: CharactersModal<'a>,
     _dialog_outcome: DialogOutcome,
+    _flag_outcome: FlagOutcome,
+    _terminal: Terminal<B>,
+
+    _characters_modal: CharactersModal<'a>,
+    _debug_panel: DebugPanel<'a>,
+    _mode_panel: ModePanel,
     _realm_modal: RealmModal<'a>,
+    _title: Title,
 }
 
 impl<'a, B: Backend> UI<'a, B> {
@@ -62,30 +74,39 @@ impl<'a, B: Backend> UI<'a, B> {
         _terminal.clear().unwrap();
         _terminal.hide_cursor().unwrap();
 
+        let component_options = UIComponentOptions {
+            output_options: output_options.clone(),
+        };
+
         Self {
-            _terminal,
-            _state_flags: UIStateFlags::NONE,
+            state_flags: UIStateFlags::NONE,
+
             _dialog_outcome: output_options.dialog_outcome,
+            _flag_outcome: output_options.flag_outcome,
+            _terminal,
 
             // components
-            _debug_panel: DebugPanel::new(),
-            _title: Title::new(),
-            _characters_modal: CharactersModal::new(),
-            _realm_modal: RealmModal::new(),
+            _characters_modal: CharactersModal::new(component_options.clone()),
+            _debug_panel: DebugPanel::new(component_options.clone()),
+            _mode_panel: ModePanel::new(component_options.clone()),
+            _realm_modal: RealmModal::new(component_options.clone()),
+            _title: Title::new(component_options.clone()),
         }
     }
 
     pub fn render(&mut self, options: UIRenderOptions) {
         match options.message {
             IncomeMessageType::Message(output) => {
-                self._debug_panel.add_item(output);
+                self._debug_panel
+                    .set_mode(options.client_flags.contains(ClientFlags::IN_DEBUG_MODE))
+                    .add_item(output);
             },
             IncomeMessageType::ChooseCharacter(characters) => {
-                self._state_flags.set(UIStateFlags::IS_CHARACTERS_MODAL_OPENED, true);
+                self.state_flags.set(UIStateFlags::IS_CHARACTERS_MODAL_OPENED, true);
                 self._characters_modal.set_items(characters);
             },
             IncomeMessageType::ChooseRealm(realms) => {
-                self._state_flags.set(UIStateFlags::IS_REALM_MODAL_OPENED, true);
+                self.state_flags.set(UIStateFlags::IS_REALM_MODAL_OPENED, true);
                 self._realm_modal.set_items(realms);
             },
             IncomeMessageType::KeyEvent(modifiers, key_code) => {
@@ -98,7 +119,8 @@ impl<'a, B: Backend> UI<'a, B> {
                 .direction(Direction::Vertical)
                 .margin(MARGIN)
                 .constraints([
-                    Constraint::Percentage(12),
+                    Constraint::Length(3),
+                    Constraint::Length(4),
                     Constraint::Percentage(76),
                     Constraint::Percentage(12),
                 ])
@@ -109,55 +131,29 @@ impl<'a, B: Backend> UI<'a, B> {
                 .constraints([
                     Constraint::Percentage(100),
                 ])
-                .split(chunks[1]);
+                .split(chunks[2]);
 
             self._title.render(frame, chunks[0]);
+            self._mode_panel.render(frame, chunks[1]);
             self._debug_panel.render(frame, output_panels[0]);
 
-            if self._state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
-                self._characters_modal.render(frame, chunks[1])
+            if self.state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
+                self._characters_modal.render(frame, chunks[2])
             }
 
-            if self._state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
-                self._realm_modal.render(frame, chunks[1])
+            if self.state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
+                self._realm_modal.render(frame, chunks[2])
             }
 
         }).unwrap();
     }
 
     fn handle_key_event(&mut self, modifiers: KeyModifiers, key_code: KeyCode) {
-        // TODO: move parts of this into related components
+        self._characters_modal.handle_key_event(modifiers, key_code, &mut self.state_flags);
+        self._mode_panel.handle_key_event(modifiers, key_code, &mut self.state_flags);
+        self._realm_modal.handle_key_event(modifiers, key_code, &mut self.state_flags);
+
         match key_code {
-            KeyCode::Up => {
-                if self._state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
-                    self._characters_modal.prev();
-                }
-
-                if self._state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
-                    self._realm_modal.prev();
-                }
-            },
-            KeyCode::Down => {
-                if self._state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
-                    self._characters_modal.next();
-                }
-
-                if self._state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
-                    self._realm_modal.next();
-                }
-            },
-            KeyCode::Enter => {
-                if self._state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
-                    self._state_flags.set(UIStateFlags::IS_CHARACTERS_MODAL_OPENED, false);
-                    self._dialog_outcome.send_selected_character(
-                        self._characters_modal.get_selected()
-                    );
-                }
-                if self._state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
-                    self._state_flags.set(UIStateFlags::IS_REALM_MODAL_OPENED, false);
-                    self._dialog_outcome.send_selected_realm(self._realm_modal.get_selected());
-                }
-            },
             KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                 // TODO: probably need exit from app in different way
                 disable_raw_mode().unwrap();
@@ -212,6 +208,11 @@ impl<'a> UIOutput<'a> {
                 self.session.lock().unwrap().selected_realm = Some(realm);
                 self.client_flags.set(ClientFlags::IN_FROZEN_MODE, false);
             },
+            OutcomeMessageType::SetUIMode(flag) => {
+                if flag == UIModeFlags::DEBUG_MODE {
+                    self.client_flags.toggle(ClientFlags::IN_DEBUG_MODE);
+                }
+            }
         };
     }
 }

--- a/src/ui/mode_panel.rs
+++ b/src/ui/mode_panel.rs
@@ -1,0 +1,87 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+use tui::backend::Backend;
+use tui::Frame;
+use tui::layout::{Alignment, Rect};
+use tui::style::{Color, Style};
+use tui::text::{Span, Spans};
+use tui::widgets::{Block, Borders, BorderType, Paragraph, Wrap};
+use crate::ipc::pipe::flag::FlagOutcome;
+
+use crate::types::traits::UIComponent;
+use crate::ui::types::{UIComponentOptions, UIModeFlags, UIStateFlags};
+
+const PANEL_TITLE: &str = "MODES";
+
+pub struct ModePanel {
+    _flag_outcome: Option<FlagOutcome>,
+    mode_flags: UIModeFlags,
+}
+
+impl ModePanel {
+    pub fn toggle_flag(&mut self, number: u8) {
+        let flag_outcome = self._flag_outcome.as_mut().unwrap();
+
+        match number {
+            1 => {
+                self.mode_flags.toggle(UIModeFlags::DEBUG_MODE);
+                flag_outcome.send_toggle_flag(UIModeFlags::DEBUG_MODE);
+            },
+            _ => {},
+        }
+    }
+
+    pub fn handle_key_event(
+        &mut self,
+        key_modifiers: KeyModifiers,
+        key_code: KeyCode,
+        _: &mut UIStateFlags
+    ) {
+        match key_code {
+            KeyCode::Char('1') => {
+                if key_modifiers.contains(KeyModifiers::CONTROL) {
+                    self.toggle_flag(1);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+impl UIComponent for ModePanel {
+    fn new(options: UIComponentOptions) -> Self {
+        Self {
+            _flag_outcome: Some(options.output_options.flag_outcome),
+            mode_flags: UIModeFlags::NONE,
+        }
+    }
+
+    fn render<B: Backend>(&mut self, frame: &mut Frame<B>, rect: Rect) {
+        let block = Block::default()
+            .title(PANEL_TITLE)
+            .title_alignment(Alignment::Center)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Double);
+
+        let help_text = vec![
+            Span::styled(
+                "To toggle mode use CTRL + <NUMBER>",
+                Style::default().fg(Color::LightBlue)
+            )
+        ];
+
+        let mut spans = vec![];
+
+        if self.mode_flags.contains(UIModeFlags::DEBUG_MODE) {
+            spans.push(Span::styled("[1] DEBUG", Style::default().fg(Color::LightGreen)));
+        } else {
+            spans.push(Span::raw("[1] DEBUG"));
+        }
+
+        let paragraph = Paragraph::new(vec![Spans::from(help_text), Spans::from(spans)])
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: true })
+            .block(block);
+
+        frame.render_widget(paragraph, rect);
+    }
+}

--- a/src/ui/title.rs
+++ b/src/ui/title.rs
@@ -5,13 +5,14 @@ use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, BorderType, Paragraph, Wrap};
 
 use crate::types::traits::UIComponent;
+use crate::ui::types::{UIComponentOptions};
 
 const APP_NAME: &str = "Idewave CLI";
 
 pub struct Title;
 
 impl UIComponent for Title {
-    fn new() -> Self {
+    fn new(_: UIComponentOptions) -> Self {
         Self
     }
 

--- a/src/ui/types.rs
+++ b/src/ui/types.rs
@@ -1,14 +1,24 @@
 use bitflags::bitflags;
+use crate::client::types::ClientFlags;
 
 use crate::ipc::pipe::dialog::DialogOutcome;
+use crate::ipc::pipe::flag::FlagOutcome;
 use crate::ipc::pipe::types::IncomeMessageType;
 
-pub struct UIRenderOptions {
+pub struct UIRenderOptions<'a> {
     pub message: IncomeMessageType,
+    pub client_flags: &'a ClientFlags,
 }
 
+#[derive(Clone)]
 pub struct UIOutputOptions {
     pub dialog_outcome: DialogOutcome,
+    pub flag_outcome: FlagOutcome,
+}
+
+#[derive(Clone)]
+pub struct UIComponentOptions {
+    pub output_options: UIOutputOptions,
 }
 
 bitflags! {
@@ -16,5 +26,12 @@ bitflags! {
         const NONE = 0x00000000;
         const IS_CHARACTERS_MODAL_OPENED = 0x00000001;
         const IS_REALM_MODAL_OPENED = 0x00000010;
+    }
+}
+
+bitflags! {
+    pub struct UIModeFlags: u32 {
+        const NONE = 0x00000000;
+        const DEBUG_MODE = 0x00000001;
     }
 }


### PR DESCRIPTION
In this PR:
- added modes support (currently only debug mode, later will be added more modes). Each mode affect client flag, then affect internal UI renderer state. This state will be used for internal components.
- refactored key input processing (so each component handle own part)