### PR TITLE
feat: IC-56 - added output for extra details on debug messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ yaml-rust = "0.4.5"
 tokio = { version = "1", features = ["sync", "net", "io-util", "macros", "time", "rt-multi-thread"] }
 bitflags = "1.3.2"
 futures = "0.3.21"
-tui = "0.18.0"
+tui = { version = "0", features = ["crossterm"] }
 crossterm = "0.24.0"
 async-trait = "0.1.57"
+serde_json = "1.0"
 
 [dev-dependencies]
 rusty-hook = "0.11.2"

--- a/src/client/chat/log_chat_message.rs
+++ b/src/client/chat/log_chat_message.rs
@@ -11,13 +11,13 @@ pub struct Handler;
 #[async_trait]
 impl PacketHandler for Handler {
     async fn handle(&mut self, input: &mut HandlerInput) -> HandlerResult {
-        let players_map = &mut input.data_storage.lock().unwrap().players_map;
+        // let players_map = &mut input.data_storage.lock().unwrap().players_map;
 
         let mut reader = Cursor::new(input.data.as_ref().unwrap()[4..].to_vec());
         let message_type = reader.read_u8()?;
         let _language = reader.read_u32::<LittleEndian>()?;
 
-        let sender_guid = reader.read_u64::<LittleEndian>()?;
+        // let sender_guid = reader.read_u64::<LittleEndian>()?;
 
         reader.read_u32::<LittleEndian>()?;
 
@@ -26,14 +26,14 @@ impl PacketHandler for Handler {
             reader.read_until(0, &mut channel_name)?;
         }
 
-        let channel_name = match channel_name.is_empty() {
-            true => String::new(),
-            false => {
-                String::from_utf8(
-                    channel_name[..(channel_name.len() - 1) as usize].to_owned()
-                ).unwrap()
-            },
-        };
+        // let channel_name = match channel_name.is_empty() {
+        //     true => String::new(),
+        //     false => {
+        //         String::from_utf8(
+        //             channel_name[..(channel_name.len() - 1) as usize].to_owned()
+        //         ).unwrap()
+        //     },
+        // };
 
         let _target_guid = reader.read_u64::<LittleEndian>()?;
 
@@ -43,16 +43,12 @@ impl PacketHandler for Handler {
 
         reader.read_exact(&mut message)?;
 
-        let message = String::from_utf8_lossy(&message);
-
-        let sender_name = match players_map.get(&sender_guid) {
-            Some(player) => player.name.to_string(),
-            None => String::from("UNKNOWN"),
-        };
-
-        input.message_income.send_debug_message(
-            format!("[MSG] [{}] {} ({}): {}", channel_name, sender_name, sender_guid, &message)
-        );
+        // let message = String::from_utf8_lossy(&message);
+        //
+        // let sender_name = match players_map.get(&sender_guid) {
+        //     Some(player) => player.name.to_string(),
+        //     None => String::from("UNKNOWN"),
+        // };
 
         Ok(HandlerOutput::Void)
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -192,7 +192,7 @@ impl Client {
             self.handle_ai(output_sender.clone(), message_income.clone()),
             self.handle_read(input_sender.clone(), signal_receiver, message_income.clone()),
             self.handle_write(output_receiver, message_income.clone()),
-            self.handle_packets(
+            self.handle_packet(
                 input_receiver,
                 signal_sender.clone(),
                 output_sender.clone(),
@@ -234,10 +234,17 @@ impl Client {
                     client_flags.lock().unwrap().clone()
                 };
 
+                let message = {
+                    let mut guard = income_message_pipe.lock().unwrap();
+                    guard.recv()
+                };
+
                 ui.render(UIRenderOptions {
-                    message: income_message_pipe.lock().unwrap().recv(),
+                    message,
                     client_flags: &client_flags,
                 });
+
+                ui.handle_debug_channel();
             }
         })
     }
@@ -283,7 +290,7 @@ impl Client {
         })
     }
 
-    fn handle_packets(
+    fn handle_packet(
         &mut self,
         mut input_receiver: Receiver<Vec<u8>>,
         signal_sender: Sender<Signal>,

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -1,3 +1,4 @@
+use std::io::{Error, ErrorKind};
 use tui::backend::Backend;
 use tui::Frame;
 use tui::layout::Rect;
@@ -13,6 +14,47 @@ pub trait Processor {
 pub trait UIComponent {
     fn new(options: UIComponentOptions) -> Self where Self: Sized;
     fn render<B: Backend>(&mut self, frame: &mut Frame<B>, rect: Rect);
+}
+
+pub trait Pagination {
+    fn get_page_number(
+        index: usize,
+        items_count: usize,
+        per_page: usize
+    ) -> Result<usize, Error> {
+        let total_pages = 0..=items_count / per_page;
+        for page in total_pages.rev() {
+            if index >= per_page * page {
+                return Ok(page);
+            }
+        }
+
+        Err(Error::new(
+            ErrorKind::Other,
+            format!("Cannot get page number for {} ({}/{})", index, items_count, per_page))
+        )
+    }
+
+    fn get_relative_index(page: usize, per_page: usize, index: usize) -> Result<usize, Error> {
+        let start = page * per_page;
+        let end = (page + 1) * per_page - 1;
+
+        let mut counter = 0;
+        for i in start..=end {
+            if index == i {
+                return Ok(counter);
+            }
+            counter += 1;
+        }
+
+        Err(Error::new(
+            ErrorKind::Other,
+            format!(
+                "Cannot get relative index for {} ({}/{}) on range {}..{}",
+                index, page, per_page, start, end
+            ))
+        )
+    }
 }
 
 #[async_trait]

--- a/src/ui/characters_modal.rs
+++ b/src/ui/characters_modal.rs
@@ -81,11 +81,13 @@ impl<'a> CharactersModal<'a> {
             KeyCode::Up => {
                 if state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
                     self.prev();
+                    state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
                 }
             },
             KeyCode::Down => {
                 if state_flags.contains(UIStateFlags::IS_CHARACTERS_MODAL_OPENED) {
                     self.next();
+                    state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
                 }
             },
             KeyCode::Enter => {

--- a/src/ui/debug_details_panel.rs
+++ b/src/ui/debug_details_panel.rs
@@ -1,0 +1,57 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+use tui::backend::Backend;
+use tui::Frame;
+use tui::layout::{Alignment, Rect};
+use tui::style::{Color, Modifier, Style};
+use tui::text::{Span, Spans};
+use tui::widgets::{Block, Borders, BorderType, Clear, List, ListItem, ListState, Paragraph, Wrap};
+
+use crate::ipc::pipe::types::LoggerOutput;
+use crate::types::traits::UIComponent;
+use crate::ui::MARGIN;
+use crate::ui::types::{UIComponentOptions, UIStateFlags};
+
+const PANEL_TITLE: &str = "DEBUG DETAILS";
+
+pub struct DebugDetailsPanel<'a> {
+    items: Vec<Spans<'a>>,
+    state: ListState,
+}
+
+impl<'a> DebugDetailsPanel<'a> {
+    pub fn add_item(&mut self, output: String) -> &mut Self {
+        self.items = vec![Spans::from(output)];
+        self
+    }
+}
+
+impl<'a> UIComponent for DebugDetailsPanel<'a> {
+    fn new(_: UIComponentOptions) -> Self {
+        Self {
+            items: vec![],
+            state: ListState::default(),
+        }
+    }
+
+    fn render<B: Backend>(&mut self, frame: &mut Frame<B>, rect: Rect) {
+        let block = Block::default()
+            .title(PANEL_TITLE)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain);
+
+        let items_amount = self.items.len();
+
+        let mut start_index: usize = 0;
+        if items_amount > rect.height as usize {
+            start_index = items_amount - (rect.height - MARGIN * 2) as usize;
+        }
+
+        let paragraph = Paragraph::new(self.items[start_index..].to_vec())
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: true })
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .block(block);
+
+        frame.render_widget(paragraph, rect);
+    }
+}

--- a/src/ui/debug_panel.rs
+++ b/src/ui/debug_panel.rs
@@ -1,20 +1,29 @@
+use std::sync::mpsc::Sender;
+use crossterm::event::{KeyCode, KeyModifiers};
+use serde_json::Value;
 use tui::backend::Backend;
 use tui::Frame;
 use tui::layout::{Alignment, Rect};
-use tui::style::{Color, Style};
+use tui::style::{Color, Modifier, Style};
 use tui::text::{Span, Spans};
-use tui::widgets::{Block, Borders, BorderType, Paragraph, Wrap};
+use tui::widgets::{Block, Borders, BorderType, Clear, List, ListItem, ListState, Paragraph, Wrap};
 
 use crate::ipc::pipe::types::LoggerOutput;
-use crate::types::traits::UIComponent;
+use crate::types::traits::{Pagination, UIComponent};
 use crate::ui::MARGIN;
-use crate::ui::types::{UIComponentOptions};
+use crate::ui::types::{UIComponentOptions, UIStateFlags};
 
 const PANEL_TITLE: &str = "DEBUG";
 
 pub struct DebugPanel<'a> {
-    items: Vec<Spans<'a>>,
+    items: Vec<ListItem<'a>>,
+    details: Vec<String>,
+    state: ListState,
     debug_mode: bool,
+    sender: Sender<String>,
+    start_index: usize,
+    per_page: u16,
+    absolute_index: Option<usize>,
 }
 
 impl<'a> DebugPanel<'a> {
@@ -27,7 +36,7 @@ impl<'a> DebugPanel<'a> {
         let message = self.generate_message(output);
 
         if !message.content.is_empty() {
-            self.items.push(Spans::from(message));
+            self.items.push(ListItem::new(Spans::from(message)));
         }
 
         self
@@ -35,31 +44,141 @@ impl<'a> DebugPanel<'a> {
 
     fn generate_message(&mut self, output: LoggerOutput) -> Span<'a> {
         match output {
-            LoggerOutput::Debug(data) if !data.is_empty() && self.debug_mode => Span::styled(
-                format!("[DEBUG]: {}\n", data), Style::default().fg(Color::DarkGray)
-            ),
-            LoggerOutput::Error(data) if !data.is_empty() => Span::styled(
-                format!("[ERROR]: {}\n", data), Style::default().fg(Color::Red)
-            ),
-            LoggerOutput::Success(data) if !data.is_empty() => Span::styled(
-                format!("[SUCCESS]: {}\n", data), Style::default().fg(Color::LightGreen)
-            ),
-            LoggerOutput::Server(data) if !data.is_empty() => Span::styled(
-                format!("[SERVER]: {}\n", data), Style::default().fg(Color::LightMagenta)
-            ),
-            LoggerOutput::Client(data) if !data.is_empty() => Span::styled(
-                format!("[CLIENT]: {}\n", data), Style::default().fg(Color::LightBlue)
-            ),
+            LoggerOutput::Debug(data) if !data.is_empty() => {
+                let (message, details) = Self::parse_input(data);
+                self.details.push(details);
+
+                Span::styled(
+                    format!("[DEBUG]: {}", message), Style::default().fg(Color::DarkGray)
+                )
+            },
+            LoggerOutput::Error(data) if !data.is_empty() => {
+                let (message, details) = Self::parse_input(data);
+                self.details.push(details);
+
+                Span::styled(
+                    format!("[ERROR]: {}", message), Style::default().fg(Color::Red)
+                )
+            },
+            LoggerOutput::Success(data) if !data.is_empty() => {
+                let (message, details) = Self::parse_input(data);
+                self.details.push(details);
+
+                Span::styled(
+                    format!("[SUCCESS]: {}", message), Style::default().fg(Color::LightGreen)
+                )
+            },
+            LoggerOutput::Server(data) if !data.is_empty() => {
+                let (message, details) = Self::parse_input(data);
+                self.details.push(details);
+
+                Span::styled(
+                    format!("[SERVER]: {}", message), Style::default().fg(Color::LightMagenta)
+                )
+            },
+            LoggerOutput::Client(data) if !data.is_empty() => {
+                let (message, details) = Self::parse_input(data);
+                self.details.push(details);
+
+                Span::styled(
+                    format!("[CLIENT]: {}", message), Style::default().fg(Color::LightBlue)
+                )
+            },
             _ => Span::raw(""),
         }
     }
+
+    pub fn prev(&mut self) {
+        let absolute_index = match self.absolute_index {
+            Some(i) => if i == 0 { self.items.len() - 1 } else { i - 1 },
+            None => self.items.len() - 1,
+        };
+        self.calculate_indexes(absolute_index);
+        self.sender.send(self.details[absolute_index].to_string()).unwrap();
+    }
+
+    pub fn next(&mut self) {
+        let absolute_index = match self.absolute_index {
+            Some(i) => if i >= self.items.len() - 1 { 0 } else { i + 1 },
+            None => 0,
+        };
+        self.calculate_indexes(absolute_index);
+        self.sender.send(self.details[absolute_index].to_string()).unwrap();
+    }
+
+    pub fn set_pagination(&mut self, per_page: u16) {
+        self.per_page = per_page;
+    }
+
+    pub fn handle_key_event(
+        &mut self,
+        _: KeyModifiers,
+        key_code: KeyCode,
+        state_flags: &mut UIStateFlags
+    ) {
+        match key_code {
+            KeyCode::Up => {
+                if !state_flags.contains(UIStateFlags::IS_EVENT_HANDLED) {
+                    if self.debug_mode {
+                        self.prev();
+                        state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
+                    }
+                }
+            },
+            KeyCode::Down => {
+                if !state_flags.contains(UIStateFlags::IS_EVENT_HANDLED) {
+                    if self.debug_mode {
+                        self.next();
+                        state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+
+    fn calculate_indexes(&mut self, absolute_index: usize) {
+        self.absolute_index = Some(absolute_index);
+
+        let page = Self::get_page_number(
+            absolute_index, self.items.len(), self.per_page as usize
+        ).unwrap();
+
+        self.start_index = page * self.per_page as usize;
+
+        let relative_index = Self::get_relative_index(
+            page, self.per_page as usize, absolute_index
+        ).unwrap();
+
+        self.state.select(Some(relative_index));
+    }
+
+    fn parse_input(data: String) -> (String, String) {
+        let mut message = data.to_string();
+        let mut details = String::new();
+        if let Ok(json) = serde_json::from_str::<Value>(&data) {
+            message = json["title"].to_string();
+            if let Some(info) = json["details"].as_str() {
+                details = info.to_string();
+            }
+        }
+
+        (message, details)
+    }
 }
 
+impl<'a> Pagination for DebugPanel<'a> {}
 impl<'a> UIComponent for DebugPanel<'a> {
-    fn new(_: UIComponentOptions) -> Self {
+    fn new(options: UIComponentOptions) -> Self {
         Self {
             items: vec![],
+            details: vec![],
+            state: ListState::default(),
             debug_mode: false,
+            sender: options.sender.clone(),
+            start_index: 0,
+            per_page: 0,
+            absolute_index: None,
         }
     }
 
@@ -69,17 +188,27 @@ impl<'a> UIComponent for DebugPanel<'a> {
             .borders(Borders::ALL)
             .border_type(BorderType::Plain);
 
-        let mut offset: usize = 0;
-        if self.items.len() > rect.height as usize {
-            offset = self.items.len() - (rect.height - MARGIN * 2) as usize;
+        let items_amount = self.items.len();
+
+        let mut start_index: usize = 0;
+        if items_amount > rect.height as usize {
+            start_index = match self.debug_mode {
+                true => self.start_index,
+                _ => items_amount - (rect.height - MARGIN * 2) as usize,
+            }
         }
 
-        let paragraph = Paragraph::new(self.items[offset..].to_vec())
-            .alignment(Alignment::Left)
-            .wrap(Wrap { trim: true })
-            .style(Style::default().fg(Color::White).bg(Color::Black))
-            .block(block);
+        let mut list = List::new(self.items[start_index..].to_vec())
+            .block(block)
+            .style(Style::default().fg(Color::White));
 
-        frame.render_widget(paragraph, rect);
+        if self.debug_mode {
+            list = list.highlight_style(
+                Style::default().add_modifier(Modifier::ITALIC).bg(Color::Gray)
+            );
+        }
+
+        frame.render_widget(Clear, rect);
+        frame.render_stateful_widget(list, rect, &mut self.state);
     }
 }

--- a/src/ui/realm_modal.rs
+++ b/src/ui/realm_modal.rs
@@ -81,11 +81,13 @@ impl<'a> RealmModal<'a> {
             KeyCode::Up => {
                 if state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
                     self.prev();
+                    state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
                 }
             },
             KeyCode::Down => {
                 if state_flags.contains(UIStateFlags::IS_REALM_MODAL_OPENED) {
                     self.next();
+                    state_flags.set(UIStateFlags::IS_EVENT_HANDLED, true);
                 }
             },
             KeyCode::Enter => {

--- a/src/ui/types.rs
+++ b/src/ui/types.rs
@@ -1,3 +1,4 @@
+use std::sync::mpsc::Sender;
 use bitflags::bitflags;
 use crate::client::types::ClientFlags;
 
@@ -19,6 +20,7 @@ pub struct UIOutputOptions {
 #[derive(Clone)]
 pub struct UIComponentOptions {
     pub output_options: UIOutputOptions,
+    pub sender: Sender<String>,
 }
 
 bitflags! {
@@ -26,6 +28,7 @@ bitflags! {
         const NONE = 0x00000000;
         const IS_CHARACTERS_MODAL_OPENED = 0x00000001;
         const IS_REALM_MODAL_OPENED = 0x00000010;
+        const IS_EVENT_HANDLED = 0x00000100;
     }
 }
 


### PR DESCRIPTION
Within this PR added next features:

- added extra panel that will be displayed in DEBUG mode, this panel need to output extra details on debug messages
- added scrolling through messages history (client stores last selected message, so if turn off DEBUG mode output will be scrolled to most recent message, but when turn on again client will scroll to last selected message)

Notice: history scrolling will work ONLY in DEBUG mode. For now I see no sense to allow it without extra output.