### PR TITLE
feat: IC-94 - support character auto-creation

### DIFF
--- a/src/primary/client/player/check_character_create_status.rs
+++ b/src/primary/client/player/check_character_create_status.rs
@@ -1,0 +1,90 @@
+use async_trait::async_trait;
+
+use crate::packet::custom_fields::TerminatedString;
+use crate::packet::player::CharCreateOutcome;
+use crate::primary::client::Opcode;
+use crate::primary::client::player::globals::CharacterEnumOutcome;
+use crate::primary::client::player::traits::CharacterCreateToolkit;
+use crate::primary::client::player::types::CharacterCreateResponseCode;
+use crate::primary::traits::packet_handler::PacketHandler;
+use crate::primary::types::{HandlerInput, HandlerResult};
+use crate::types::HandlerOutput;
+
+#[derive(WorldPacket, Serialize, Deserialize, Debug)]
+#[options(no_opcode)]
+struct Income {
+    code: u8,
+}
+
+pub struct Handler;
+#[async_trait]
+impl PacketHandler for Handler {
+    async fn handle(&mut self, input: &mut HandlerInput) -> HandlerResult {
+        let mut response = Vec::new();
+
+        let (Income { code, .. }, json) = Income::from_binary(&input.data)?;
+        response.push(HandlerOutput::ResponseMessage(
+            Opcode::get_opcode_name(input.opcode as u32)
+                .unwrap_or(format!("Unknown opcode: {}", input.opcode)),
+            Some(json),
+        ));
+
+        let auto_create_character_for_new_account = {
+            let guard = input.session.lock().await;
+            let config = guard.get_config()?;
+            config.common.auto_create_character_for_new_account
+        };
+
+        match code {
+            CharacterCreateResponseCode::CHAR_CREATE_SUCCESS => {
+                response.push(HandlerOutput::SuccessMessage(
+                    "Character created successfully".into(),
+                    None,
+                ));
+            },
+            CharacterCreateResponseCode::CHAR_CREATE_NAME_IN_USE => {
+                if auto_create_character_for_new_account {
+                    let random_name = Self::generate_random_string(true);
+                    response.push(HandlerOutput::ResponseMessage(
+                        format!("Creating character with name \"{}\"", random_name),
+                        None,
+                    ));
+
+                    response.push(HandlerOutput::Data(CharCreateOutcome {
+                        name: TerminatedString::from(random_name),
+                        race: Self::get_random_race(),
+                        class: Self::get_random_class(),
+                        gender: Self::get_random_gender(),
+                        skin: 0,
+                        face: 0,
+                        hair_style: 0,
+                        hair_color: 0,
+                        facial_hair: 0,
+                        outfit_id: 0,
+                    }.unpack()?));
+
+                    response.push(HandlerOutput::Data(CharacterEnumOutcome::default().unpack()?));
+                }
+            },
+            CharacterCreateResponseCode::CHAR_CREATE_ACCOUNT_LIMIT => {
+                response.push(HandlerOutput::SuccessMessage(
+                    "Account limit is exceeded".into(),
+                    None,
+                ));
+                response.push(HandlerOutput::Drop);
+            },
+            CharacterCreateResponseCode::CHAR_CREATE_SERVER_LIMIT => {
+                response.push(HandlerOutput::SuccessMessage(
+                    "Server limit is exceeded".into(),
+                    None,
+                ));
+                response.push(HandlerOutput::Drop);
+            },
+            _ => {},
+        }
+
+        Ok(response)
+    }
+}
+
+impl CharacterCreateToolkit for Handler {}

--- a/src/primary/client/player/globals.rs
+++ b/src/primary/client/player/globals.rs
@@ -8,3 +8,9 @@ with_opcode! {
         pub guid: u64,
     }
 }
+
+with_opcode! {
+    @world_opcode(Opcode::CMSG_CHAR_ENUM)
+    #[derive(WorldPacket, Serialize, Deserialize, Debug, Default)]
+    pub struct CharacterEnumOutcome {}
+}

--- a/src/primary/client/player/mod.rs
+++ b/src/primary/client/player/mod.rs
@@ -4,6 +4,8 @@ mod handle_update_data;
 pub mod types;
 pub mod get_characters_list;
 pub mod player_login;
+mod check_character_create_status;
+mod traits;
 
 use crate::primary::client::opcodes::Opcode;
 use crate::primary::traits::processor::Processor;
@@ -49,6 +51,11 @@ impl Processor for PlayerProcessor {
                     Box::new(player_login::Handler),
                 ]
             },
+            Opcode::SMSG_CHAR_CREATE => {
+                vec![
+                    Box::new(check_character_create_status::Handler),
+                ]
+            },
             _ => vec![],
         };
 
@@ -59,12 +66,13 @@ impl Processor for PlayerProcessor {
 pub mod packet {
     use crate::primary::client::Opcode;
     use crate::primary::macros::with_opcode;
+    use crate::primary::types::TerminatedString;
 
     with_opcode! {
         @world_opcode(Opcode::CMSG_CHAR_CREATE)
         #[derive(WorldPacket, Serialize, Deserialize, Debug)]
         pub struct CharCreateOutcome {
-            pub name: String,
+            pub name: TerminatedString,
             pub race: u8,
             pub class: u8,
             pub gender: u8,

--- a/src/primary/client/player/traits.rs
+++ b/src/primary/client/player/traits.rs
@@ -1,0 +1,60 @@
+use rand::distributions::Alphanumeric;
+use rand::prelude::SliceRandom;
+use rand::{Rng, thread_rng};
+use crate::player::{Class, Gender, Race};
+
+pub trait CharacterCreateToolkit {
+    fn generate_random_string(capitalize: bool) -> String {
+        let mut rng = thread_rng();
+        let random_length = rng.gen_range(9..=11);
+
+        let string: String = rng
+            .sample_iter(&Alphanumeric)
+            .filter(|c| c.is_ascii_alphabetic())
+            .take(random_length)
+            .map(|c| c as char)
+            .collect();
+
+        if capitalize {
+            let first_letter = string.chars().next().unwrap();
+
+            format!("{}{}", first_letter.to_uppercase(), string.to_lowercase())
+        } else {
+            format!("{}", string.to_lowercase())
+        }
+    }
+
+    fn get_random_race() -> u8 {
+        let races = vec![
+            Race::HUMAN,
+            Race::ORC,
+            Race::DWARF,
+            Race::NIGHTELF,
+            Race::UNDEAD,
+            Race::TROLL,
+        ];
+
+        let mut rng = thread_rng();
+        *races.choose(&mut rng).unwrap()
+    }
+
+    fn get_random_class() -> u8 {
+        let races = vec![
+            Class::WARRIOR,
+            Class::ROGUE,
+        ];
+
+        let mut rng = thread_rng();
+        *races.choose(&mut rng).unwrap()
+    }
+
+    fn get_random_gender() -> u8 {
+        let races = vec![
+            Gender::GENDER_MALE,
+            Gender::GENDER_FEMALE,
+        ];
+
+        let mut rng = thread_rng();
+        *races.choose(&mut rng).unwrap()
+    }
+}

--- a/src/primary/client/player/types.rs
+++ b/src/primary/client/player/types.rs
@@ -1575,3 +1575,34 @@ bitflags! {
         const XP_USER_DISABLED = 0x02000000;
     }
 }
+
+#[non_exhaustive]
+pub struct CharacterCreateResponseCode;
+
+#[allow(dead_code)]
+impl CharacterCreateResponseCode {
+    pub const CHAR_CREATE_IN_PROGRESS: u8 = 46;
+    pub const CHAR_CREATE_SUCCESS: u8 = 47;
+    pub const CHAR_CREATE_ERROR: u8 = 48;
+    pub const CHAR_CREATE_FAILED: u8 = 49;
+    pub const CHAR_CREATE_NAME_IN_USE: u8 = 50;
+    pub const CHAR_CREATE_DISABLED: u8 = 51;
+    pub const CHAR_CREATE_PVP_TEAMS_VIOLATION: u8 = 52;
+    pub const CHAR_CREATE_SERVER_LIMIT: u8 = 53;
+    pub const CHAR_CREATE_ACCOUNT_LIMIT: u8 = 54;
+    pub const CHAR_CREATE_SERVER_QUEUE: u8 = 55;
+    pub const CHAR_CREATE_ONLY_EXISTING: u8 = 56;
+    pub const CHAR_CREATE_EXPANSION: u8 = 57;
+    pub const CHAR_CREATE_EXPANSION_CLASS: u8 = 58;
+    pub const CHAR_CREATE_LEVEL_REQUIREMENT: u8 = 59;
+    pub const CHAR_CREATE_UNIQUE_CLASS_LIMIT: u8 = 60;
+    pub const CHAR_CREATE_CHARACTER_IN_GUILD: u8 = 61;
+    pub const CHAR_CREATE_RESTRICTED_RACECLASS: u8 = 62;
+    pub const CHAR_CREATE_CHARACTER_CHOOSE_RACE: u8 = 63;
+    pub const CHAR_CREATE_CHARACTER_ARENA_LEADER: u8 = 64;
+    pub const CHAR_CREATE_CHARACTER_DELETE_MAIL: u8 = 65;
+    pub const CHAR_CREATE_CHARACTER_SWAP_FACTION: u8 = 66;
+    pub const CHAR_CREATE_CHARACTER_RACE_ONLY: u8 = 67;
+    pub const CHAR_CREATE_CHARACTER_GOLD_LIMIT: u8 = 68;
+    pub const CHAR_CREATE_FORCE_LOGIN: u8 = 69;
+}

--- a/src/primary/client/realm/request_characters.rs
+++ b/src/primary/client/realm/request_characters.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 
-use crate::primary::macros::with_opcode;
-use crate::primary::client::opcodes::Opcode;
+use crate::primary::client::player::globals::CharacterEnumOutcome;
 use crate::primary::types::{
     HandlerInput,
     HandlerOutput,
@@ -9,17 +8,11 @@ use crate::primary::types::{
 };
 use crate::primary::traits::packet_handler::PacketHandler;
 
-with_opcode! {
-    @world_opcode(Opcode::CMSG_CHAR_ENUM)
-    #[derive(WorldPacket, Serialize, Deserialize, Debug, Default)]
-    struct Outcome {}
-}
-
 pub struct Handler;
 #[async_trait]
 impl PacketHandler for Handler {
     async fn handle(&mut self, _: &mut HandlerInput) -> HandlerResult {
-        let response = vec![HandlerOutput::Data(Outcome::default().unpack()?)];
+        let response = vec![HandlerOutput::Data(CharacterEnumOutcome::default().unpack()?)];
 
         Ok(response)
     }

--- a/src/primary/client/spell/handle_spell_go.rs
+++ b/src/primary/client/spell/handle_spell_go.rs
@@ -26,13 +26,21 @@ impl PacketHandler for Handler {
             Some(json),
         ));
 
-        let my_guid = {
-            input.session.lock().await.me.as_ref().unwrap().guid
+        let my_guid: Option<u64> = {
+            let guard = input.session.lock().await;
+            let me = guard.me.as_ref();
+            if me.is_some() {
+                Some(me.unwrap().guid)
+            } else {
+                None
+            }
         };
 
-        input.session.lock().await.action_flags.set(
-            ActionFlags::IS_CASTING, my_guid == caster_guid
-        );
+        if my_guid.is_some() {
+            input.session.lock().await.action_flags.set(
+                ActionFlags::IS_CASTING, my_guid.unwrap() == caster_guid
+            );
+        }
 
         Ok(response)
     }

--- a/src/primary/config/mod.rs
+++ b/src/primary/config/mod.rs
@@ -8,10 +8,13 @@ use yaml_rust::{Yaml, YamlLoader};
 
 pub mod types;
 
-use crate::primary::config::types::{AddonInfo, ChannelLabels, ConnectionData};
+use crate::primary::config::types::{AddonInfo, ChannelLabels, CommonOptions, ConnectionData};
 use crate::primary::errors::{ConfigError};
 
-const CONFIG_CONTENT: &str = r##"connection_data:
+const CONFIG_CONTENT: &str = r##"common:
+  auto_create_character_for_new_account: false
+
+connection_data:
   127.0.0.1:
     account_name:
         password: "safe_password"
@@ -68,6 +71,7 @@ pub struct EnvConfigParams<'a> {
 
 #[derive(Debug)]
 pub struct Config {
+    pub common: CommonOptions,
     pub connection_data: ConnectionData,
     pub addons: Vec<AddonInfo>,
     pub channel_labels: ChannelLabels,
@@ -80,7 +84,9 @@ impl Config {
         let data = read_to_string(params.config_path).map_err(|_| ConfigError::NotFound)?;
         let docs = YamlLoader::load_from_str(&data).map_err(ConfigError::ScanError)?;
 
-        let connection_data = Self::parse_connection_data(
+        let common_options = Self::parse_common_options(&docs[0]["common"]);
+
+        let connection_data = Self::parse_connection_options(
             &docs[0]["connection_data"][params.host],
             params.account,
         );
@@ -88,7 +94,8 @@ impl Config {
         let channel_labels = Self::parse_channels_data(&docs[0]["channel_labels"]);
 
         Ok(Self {
-            connection_data,
+            common: common_options,
+            connection_data: connection_data,
             addons: vec![
                 AddonInfo { name: "Blizzard_AchievementUI".to_string(), flags: 0, modulus_crc: 0, urlcrc_crc: 0 },
                 AddonInfo { name: "Blizzard_ArenaUI".to_string(), flags: 0, modulus_crc: 0, urlcrc_crc: 0 },
@@ -118,7 +125,7 @@ impl Config {
         })
     }
 
-    fn parse_connection_data(config: &Yaml, account: &str) -> ConnectionData {
+    fn parse_connection_options(config: &Yaml, account: &str) -> ConnectionData {
         let config = &config[account];
         let autoselect = config["autoselect"].as_hash().unwrap();
 
@@ -143,6 +150,16 @@ impl Config {
             lfg: config["lfg"].as_str().unwrap().to_string(),
             common: config["common"].as_str().unwrap().to_string(),
             trade: config["trade"].as_str().unwrap().to_string(),
+        }
+    }
+
+    fn parse_common_options(config: &Yaml) -> CommonOptions {
+        let auto_create_character_for_new_account = {
+            config["auto_create_character_for_new_account"].as_bool().unwrap()
+        };
+
+        return CommonOptions {
+            auto_create_character_for_new_account,
         }
     }
 }
@@ -199,7 +216,7 @@ mod tests {
         let docs = YamlLoader::load_from_str(&file_content)
             .map_err(ConfigError::ScanError).unwrap();
 
-        let connection_data = Config::parse_connection_data(
+        let connection_data = Config::parse_connection_options(
             &docs[0]["connection_data"][HOST],
             ACCOUNT,
         );
@@ -213,6 +230,9 @@ mod tests {
         assert_eq!(channel_labels.common, "COMMON");
         assert_eq!(channel_labels.lfg, "LFG");
         assert_eq!(channel_labels.trade, "TRADE");
+
+        let common_options = Config::parse_common_options(&docs[0]["common"]);
+        assert_eq!(common_options.auto_create_character_for_new_account, false);
 
         temp_dir.close().unwrap();
     }

--- a/src/primary/config/types.rs
+++ b/src/primary/config/types.rs
@@ -2,6 +2,11 @@ use std::io::{Error, Write};
 use byteorder::{LittleEndian, WriteBytesExt};
 
 #[derive(Clone, Debug)]
+pub struct CommonOptions {
+    pub auto_create_character_for_new_account: bool,
+}
+
+#[derive(Clone, Debug)]
 pub struct ConnectionData {
     pub account: String,
     pub password: String,


### PR DESCRIPTION
In config under `common` section was added new param `auto_create_character_for_new_account`. When set to `true` it allows to create character with random name, race, class and gender. To work properly, `character_name` under `autoselect` section for current account should be set into `.*`, this way the character will be autoselected after creation.