### PR TITLE
fix: IC-139 - fixed output for VALUES block type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sha-1 = { version = "0.9.8", optional = true }
 tentacli-crypto = "0.1.0"
 tentacli-formatters = "0.1.0"
 tentacli-packet = "7.0.0"
-tentacli-traits = "8.0.3"
+tentacli-traits = "8.1.0"
 tentacli-utils = "2.1.0"
 tokio = { version = "1", features = ["sync", "net", "io-util", "macros", "time", "rt-multi-thread"] }
 #tokio-util = { version = "0.7.10", features = ["io"] }

--- a/src/features/wotlk_realm/player/handle_update_data.rs
+++ b/src/features/wotlk_realm/player/handle_update_data.rs
@@ -104,17 +104,13 @@ impl PacketHandler for Handler {
     async fn handle(&mut self, input: &mut HandlerInput) -> HandlerResult {
         let mut response = Vec::new();
 
-        let (UpdateDataIncoming { blocks, .. }, json) = if input.opcode == Opcode::SMSG_UPDATE_OBJECT {
-            UpdateDataIncoming::from_binary(&input.data)?
-        } else {
-            UpdateDataIncoming::from_compressed_binary(&input.data)?
+        let (UpdateDataIncoming { blocks, blocks_amount }, _) = {
+            if input.opcode == Opcode::SMSG_UPDATE_OBJECT {
+                UpdateDataIncoming::from_binary(&input.data)?
+            } else {
+                UpdateDataIncoming::from_compressed_binary(&input.data)?
+            }
         };
-
-        response.push(HandlerOutput::ResponseMessage(
-            Opcode::get_opcode_name(input.opcode as u32)
-                .unwrap_or(format!("Unknown opcode: {}", input.opcode)),
-            Some(json),
-        ));
 
         if input.session.lock().await.me.is_none() {
             response.push(HandlerOutput::ErrorMessage(
@@ -128,10 +124,11 @@ impl PacketHandler for Handler {
             input.session.lock().await.me.as_ref().unwrap().guid
         };
 
-        for block in blocks {
-            if block.guid == 0 {
-                continue;
-            }
+        let mut refined_blocks: Vec<Block> = vec![];
+
+        for mut block in blocks {
+            let mut update_data = UpdateData::default();
+            let cloned_block = block.clone();
 
             let PackedGuid(guid) = block.guid;
 
@@ -140,6 +137,7 @@ impl PacketHandler for Handler {
             {
                 match mask {
                     m if m & ObjectTypeMask::PLAYER != 0 => {
+                        update_data = block.update_data.clone();
                         let mut object = Player {
                             update_data: block.update_data,
                             guid,
@@ -158,6 +156,7 @@ impl PacketHandler for Handler {
                         guard.players_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::UNIT != 0 => {
+                        update_data = block.update_data.clone();
                         let mut object = Unit {
                             update_data: block.update_data,
                             guid,
@@ -170,6 +169,7 @@ impl PacketHandler for Handler {
                         guard.units_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::GAMEOBJECT != 0 => {
+                        update_data = block.update_data.clone();
                         let mut object = GameObject {
                             update_data: block.update_data,
                             guid,
@@ -182,6 +182,7 @@ impl PacketHandler for Handler {
                         guard.game_objects_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::DYNAMICOBJECT != 0 => {
+                        update_data = block.update_data.clone();
                         let mut object = DynamicObject {
                             update_data: block.update_data,
                             guid,
@@ -194,6 +195,7 @@ impl PacketHandler for Handler {
                         guard.dynamic_objects_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::ITEM != 0 => {
+                        update_data = block.update_data.clone();
                         if let Some(FieldValue::Long(guid)) =
                             block.update_data.item_fields.get(&ItemField::Owner)
                         {
@@ -216,6 +218,7 @@ impl PacketHandler for Handler {
                         guard.items_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::CONTAINER != 0 => {
+                        update_data = block.update_data.clone();
                         if let Some(FieldValue::Long(guid)) =
                             block.update_data.item_fields.get(&ItemField::Owner)
                         {
@@ -238,6 +241,7 @@ impl PacketHandler for Handler {
                         guard.containers_map.insert(guid, object);
                     },
                     m if m & ObjectTypeMask::CORPSE != 0 => {
+                        update_data = block.update_data.clone();
                         let mut object = Corpse {
                             update_data: block.update_data,
                             guid,
@@ -251,8 +255,72 @@ impl PacketHandler for Handler {
                     }
                     _ => {},
                 }
+            } else {
+                let mut guard = input.data_storage.lock().unwrap();
+
+                match guid {
+                    g if guard.players_map.contains_key(&g) => {
+                        guard.players_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.units_map.contains_key(&g) => {
+                        guard.units_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.game_objects_map.contains_key(&g) => {
+                        guard.game_objects_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.dynamic_objects_map.contains_key(&g) => {
+                        guard.dynamic_objects_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.items_map.contains_key(&g) => {
+                        guard.items_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.containers_map.contains_key(&g) => {
+                        guard.containers_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    g if guard.corpses_map.contains_key(&g) => {
+                        guard.corpses_map.entry(guid).and_modify(|o| {
+                            o.update_data.extend_or_clear_source(&mut block.update_data);
+                            update_data = block.update_data.clone();
+                        });
+                    },
+                    _ => {},
+                }
             }
+
+            refined_blocks.push(Block {
+                update_data,
+                ..cloned_block
+            });
         }
+
+        let json = UpdateDataIncoming {
+            blocks_amount,
+            blocks: refined_blocks,
+        }.get_json_details()?;
+
+        response.push(HandlerOutput::ResponseMessage(
+            Opcode::get_opcode_name(input.opcode as u32)
+                .unwrap_or(format!("Unknown opcode: {}", input.opcode)),
+            Some(json),
+        ));
 
         Ok(response)
     }

--- a/src/primary/traits/Cargo.toml
+++ b/src/primary/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacli-traits"
-version = "8.0.3"
+version = "8.1.0"
 edition = "2021"
 authors = ["Sergio Ivanuzzo <sergio.ivanuzzo@gmail.com>"]
 description = "Traits and types for tentacli and related projects"

--- a/src/primary/traits/src/types/update_data.rs
+++ b/src/primary/traits/src/types/update_data.rs
@@ -32,6 +32,56 @@ impl UpdateData {
         *self == Self::default()
     }
 
+    pub fn extend_or_clear_source(&mut self, source: &mut UpdateData) {
+        if !self.player_fields.is_empty() {
+            self.player_fields.extend(source.player_fields.clone());
+        } else {
+            source.player_fields.clear();
+        }
+
+        if !self.unit_fields.is_empty() {
+            self.unit_fields.extend(source.unit_fields.clone());
+        } else {
+            source.unit_fields.clear();
+        }
+
+        if !self.object_fields.is_empty() {
+            self.object_fields.extend(source.object_fields.clone());
+        } else {
+            source.object_fields.clear();
+        }
+
+        if !self.item_fields.is_empty() {
+            self.item_fields.extend(source.item_fields.clone());
+        } else {
+            source.item_fields.clear();
+        }
+
+        if !self.game_object_fields.is_empty() {
+            self.game_object_fields.extend(source.game_object_fields.clone());
+        } else {
+            source.game_object_fields.clear();
+        }
+
+        if !self.dynamic_object_fields.is_empty() {
+            self.dynamic_object_fields.extend(source.dynamic_object_fields.clone());
+        } else {
+            source.dynamic_object_fields.clear();
+        }
+
+        if !self.container_fields.is_empty() {
+            self.container_fields.extend(source.container_fields.clone());
+        } else {
+            source.container_fields.clear();
+        }
+
+        if !self.corpse_fields.is_empty() {
+            self.corpse_fields.extend(source.corpse_fields.clone());
+        } else {
+            source.corpse_fields.clear();
+        }
+    }
+
     pub fn parse_value(option: &FieldValue) -> Vec<u32> {
         match option {
             FieldValue::Long(value) => {
@@ -188,116 +238,144 @@ impl BinaryConverter for UpdateData {
                 update_blocks.insert(index, value);
             }
 
-            let object_blocks: BTreeMap<u32, u32> = update_blocks
-                .range(0..=ObjectField::get_limit())
-                .map(|(&key, &value)| (key, value))
-                .collect();
+            let object_fields: BTreeMap<ObjectField, FieldValue> = {
+                let blocks: BTreeMap<u32, u32> = update_blocks
+                    .range(0..=ObjectField::get_limit())
+                    .map(|(&key, &value)| (key, value))
+                    .collect();
 
-            let object_fields = ObjectField::read_from(
-                object_blocks.values().copied().collect::<Vec<u32>>(),
-                &mut update_mask
-            )?;
+                ObjectField::read_from(
+                    blocks.values().copied().collect::<Vec<u32>>(),
+                    &mut update_mask
+                ).unwrap_or_default()
+            };
 
-            let mut unit_fields: BTreeMap<UnitField, FieldValue> = BTreeMap::default();
-            let mut player_fields: BTreeMap<PlayerField, FieldValue> = BTreeMap::default();
-            let mut item_fields: BTreeMap<ItemField, FieldValue> = BTreeMap::default();
-            let mut game_object_fields: BTreeMap<GameObjectField, FieldValue> = BTreeMap::default();
-            let mut dynamic_object_fields: BTreeMap<DynamicObjectField, FieldValue> = BTreeMap::default();
-            let mut container_fields: BTreeMap<ContainerField, FieldValue> = BTreeMap::default();
-            let mut corpse_fields: BTreeMap<CorpseField, FieldValue> = BTreeMap::default();
+            let mask = object_fields.get(&ObjectField::Type).and_then(|field| {
+                if let FieldValue::Integer(mask) = field {
+                    Some(*mask)
+                } else {
+                    None
+                }
+            }).unwrap_or_default();
 
-            if let Some(FieldValue::Integer(mask)) = object_fields.get(&ObjectField::Type) {
-                if mask & ObjectTypeMask::PLAYER != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        UnitField::get_limit() + 1,
-                        PlayerField::get_limit()
-                    );
+            let unit_fields: BTreeMap<UnitField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ObjectField::get_limit() + 1,
+                    UnitField::get_limit()
+                );
 
-                    player_fields = PlayerField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::UNIT != 0 {
+                    UnitField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::UNIT != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ObjectField::get_limit() + 1,
-                        UnitField::get_limit()
-                    );
+            let player_fields: BTreeMap<PlayerField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    UnitField::get_limit() + 1,
+                    PlayerField::get_limit()
+                );
 
-                    unit_fields = UnitField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::PLAYER != 0 {
+                    PlayerField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::GAMEOBJECT != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ObjectField::get_limit() + 1,
-                        GameObjectField::get_limit()
-                    );
+            let item_fields: BTreeMap<ItemField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ObjectField::get_limit() + 1,
+                    ItemField::get_limit()
+                );
 
-                    game_object_fields = GameObjectField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::ITEM != 0 {
+                    ItemField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::DYNAMICOBJECT != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ObjectField::get_limit() + 1,
-                        DynamicObjectField::get_limit()
-                    );
+            let game_object_fields: BTreeMap<GameObjectField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ObjectField::get_limit() + 1,
+                    GameObjectField::get_limit()
+                );
 
-                    dynamic_object_fields = DynamicObjectField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::GAMEOBJECT != 0 {
+                    GameObjectField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::ITEM != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ObjectField::get_limit() + 1,
-                        ItemField::get_limit()
-                    );
+            let dynamic_object_fields: BTreeMap<DynamicObjectField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ObjectField::get_limit() + 1,
+                    DynamicObjectField::get_limit()
+                );
 
-                    item_fields = ItemField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::DYNAMICOBJECT != 0 {
+                    DynamicObjectField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::CONTAINER != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ItemField::get_limit() + 1,
-                        ContainerField::get_limit()
-                    );
+            let container_fields: BTreeMap<ContainerField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ItemField::get_limit() + 1,
+                    ContainerField::get_limit()
+                );
 
-                    container_fields = ContainerField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::CONTAINER != 0 {
+                    ContainerField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
+            };
 
-                if mask & ObjectTypeMask::CORPSE != 0 {
-                    let blocks = Self::build_blocks(
-                        &update_blocks,
-                        ObjectField::get_limit() + 1,
-                        CorpseField::get_limit()
-                    );
+            let corpse_fields: BTreeMap<CorpseField, FieldValue> = {
+                let blocks = Self::build_blocks(
+                    &update_blocks,
+                    ObjectField::get_limit() + 1,
+                    CorpseField::get_limit()
+                );
 
-                    corpse_fields = CorpseField::read_from(
+                if mask == 0 || mask & ObjectTypeMask::CORPSE != 0 {
+                    CorpseField::read_from(
                         blocks.values().copied().collect::<Vec<u32>>(),
                         &mut update_mask
-                    )?;
+                    ).unwrap_or_default()
+                } else {
+                    BTreeMap::default()
                 }
-            }
+            };
 
             Ok(Self {
                 object_fields,


### PR DESCRIPTION
What was changed: now `UpdateData` try to read blocks for each fields: object, unit, player, item etc. It's so called "greedy parsing". Then in `handle_update_data` handler this data will be refined, so for example player object will be refined from item fields etc. And finally the new output from refined blocks will be built.