### PR TITLE
Fix clippy warnings across runtime and plugins

### DIFF
--- a/src/client/macros/packet/src/lib.rs
+++ b/src/client/macros/packet/src/lib.rs
@@ -211,24 +211,23 @@ impl PacketOptions {
 }
 
 fn normalize_opcode(expr: Expr) -> Expr {
-    if let Expr::Call(call) = &expr {
-        if let Expr::Path(path) = &*call.func {
-            if let Some(id) = path.path.get_ident() {
-                let name = id.to_string();
-                let ok = matches!(
-                    name.as_str(),
-                    "U8" | "U16" | "U32" | "U64" | "Text" | "Raw"
-                );
+    if let Expr::Call(call) = &expr
+        && let Expr::Path(path) = &*call.func
+        && let Some(id) = path.path.get_ident()
+    {
+        let name = id.to_string();
+        let ok = matches!(
+            name.as_str(),
+            "U8" | "U16" | "U32" | "U64" | "Text" | "Raw"
+        );
 
-                if ok && call.args.len() == 1 {
-                    let arg = call.args.first().cloned().unwrap();
-                    let v = Ident::new(&name, id.span());
-                    return syn::parse_quote! {
-                        crate::client::packet
-                            ::PacketOpcode::#v(#arg)
-                    };
-                }
-            }
+        if ok && call.args.len() == 1 {
+            let arg = call.args.first().cloned().unwrap();
+            let v = Ident::new(&name, id.span());
+            return syn::parse_quote! {
+                crate::client::packet
+                    ::PacketOpcode::#v(#arg)
+            };
         }
     }
 

--- a/src/client/packet/helpers.rs
+++ b/src/client/packet/helpers.rs
@@ -18,6 +18,7 @@ pub fn reversed_null_terminated(s: &NullTerminated<String>) -> BinResult<()> {
 }
 
 #[binrw::writer(writer)]
+#[allow(clippy::ptr_arg)]
 pub fn reversed(s: &String) -> BinResult<()> {
     let r: String = s.chars().rev().collect();
     writer.write_all(r.as_bytes())?;
@@ -25,6 +26,7 @@ pub fn reversed(s: &String) -> BinResult<()> {
 }
 
 #[binrw::writer(writer)]
+#[allow(clippy::ptr_arg)]
 pub fn just_bytes(s: &String) -> BinResult<()> {
     writer.write_all(s.as_bytes())?;
     Ok(())

--- a/src/client/packet/mod.rs
+++ b/src/client/packet/mod.rs
@@ -279,8 +279,7 @@ impl CalculateMetadata for () {
 pub trait ExtractMetadata: CalculateMetadata {
     fn extract_metadata(&self) -> HashMap<String, MetadataValue> {
         let mut context = MetadataContext::default();
-        let metadata = std::mem::take(&mut self.calculate(&mut context).metadata);
-        metadata
+        std::mem::take(&mut self.calculate(&mut context).metadata)
     }
 }
 

--- a/src/client/plugin.rs
+++ b/src/client/plugin.rs
@@ -21,6 +21,7 @@ use crate::client::types::{
 
 #[async_trait]
 pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
+    #[allow(clippy::too_many_arguments)]
     fn connect(
         self: Arc<Self>,
         mut echo_rx: Receiver<Echo>,
@@ -83,7 +84,7 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
 
             let local_cancel = shutdown.child_token();
 
-            let _ = plugin.on_connect(
+            plugin.on_connect(
                 // to send packet into write_task
                 packet_tx.clone(),
                 // to broadcast HandlerOutput to the core plugins
@@ -344,6 +345,7 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_requests(
         &self,
         requests: &mut Vec<Request>,
@@ -405,7 +407,7 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
         }
 
         if !requests.is_empty() {
-            outputs.push(HandlerOutput::Requests(requests.drain(..).collect()));
+            outputs.push(HandlerOutput::Requests(std::mem::take(requests)));
 
             self.handle_outputs(
                 Arc::new(std::mem::take(outputs)),
@@ -428,15 +430,12 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
         broadcast_tx.broadcast(OrderedOutput::new(self.label(), outputs.clone())).await?;
 
         for output in &*outputs {
-            match output {
-                HandlerOutput::Packets(packets) => {
-                    with_cancel(
-                        &format!("{}-connection, handle_outputs", self.label()),
-                        &local_cancel,
-                        packet_tx.send(packets.clone()).map_err(|e| anyhow::anyhow!(e.to_string())),
-                    ).await?;
-                },
-                _ => {},
+            if let HandlerOutput::Packets(packets) = output {
+                with_cancel(
+                    &format!("{}-connection, handle_outputs", self.label()),
+                    local_cancel,
+                    packet_tx.send(packets.clone()).map_err(|e| anyhow::anyhow!(e.to_string())),
+                ).await?;
             }
         }
 

--- a/src/client/types.rs
+++ b/src/client/types.rs
@@ -143,11 +143,11 @@ impl OrderedReceiver {
                 self.next = self.buffer.keys().next().copied();
             }
 
-            if let Some(next) = self.next {
-                if let Some(entry) = self.buffer.remove(&next) {
-                    self.next = Some(next + 1);
-                    return Ok(entry);
-                }
+            if let Some(next) = self.next
+                && let Some(entry) = self.buffer.remove(&next)
+            {
+                self.next = Some(next + 1);
+                return Ok(entry);
             }
 
             // soft-fail protection

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use tentacli::Client;
 async fn main() -> anyhow::Result<()> {
     let mut args = std::env::args().skip(1);
 
-    if let Some(cmd) = args.next() {
-        if cmd == "doctor" {
-            Client::doctor()?;
-            return Ok(());
-        }
+    if let Some(cmd) = args.next()
+        && cmd == "doctor"
+    {
+        Client::doctor()?;
+        return Ok(());
     }
 
     Client::run(None).await

--- a/src/plugins/tui/components/app/mod.rs
+++ b/src/plugins/tui/components/app/mod.rs
@@ -155,11 +155,11 @@ impl App {
                     },
                 }
 
-                if !all_echoes.is_empty() {
-                    if let Some(sender) = echo_senders.get(target) {
-                        for echo in all_echoes.drain(..) {
-                            sender.send(echo).await?;
-                        }
+                if !all_echoes.is_empty()
+                    && let Some(sender) = echo_senders.get(target)
+                {
+                    for echo in all_echoes.drain(..) {
+                        sender.send(echo).await?;
                     }
                 }
             }
@@ -191,15 +191,12 @@ impl EventHandler<log_viewer::events::SelectedIndex> for App {
 
 impl EventHandler<KeyEvent> for App {
     async fn callback(&mut self, event: KeyEvent) -> anyhow::Result<Vec<Echo>> {
-        match event.code {
-            KeyCode::Char('q') => {
-                for sender in self.echo_senders.values() {
-                    let _ = sender.send(Echo::Drop).await;
-                }
+        if let KeyCode::Char('q') = event.code {
+            for sender in self.echo_senders.values() {
+                let _ = sender.send(Echo::Drop).await;
+            }
 
-                self.shutdown.cancel();
-            },
-            _ => {},
+            self.shutdown.cancel();
         }
 
         Ok(vec![])
@@ -283,6 +280,6 @@ struct TerminalGuard;
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        let _ = ratatui::restore();
+        ratatui::restore();
     }
 }

--- a/src/plugins/tui/components/json_navigator/cursor.rs
+++ b/src/plugins/tui/components/json_navigator/cursor.rs
@@ -87,12 +87,10 @@ impl JsonCursor {
             NodeKeys::Object(keys) => Some(Metadata {
                 key: keys.get(index)?.to_string(),
                 path: self.state.path.join("/"),
-                ..Default::default()
             }),
             NodeKeys::Array(_) => Some(Metadata {
                 key: index.to_string(),
                 path: self.state.path.join("/"),
-                ..Default::default()
             }),
             _ => None,
         }

--- a/src/plugins/tui/components/json_navigator/helpers.rs
+++ b/src/plugins/tui/components/json_navigator/helpers.rs
@@ -94,7 +94,7 @@ fn format_array(arr: &[Value], indent: usize) -> String {
                 .join(", ")
         ));
 
-        if i + 1 < (arr.len() + PER_LINE - 1) / PER_LINE {
+        if i + 1 < arr.len().div_ceil(PER_LINE) {
             out.push(',');
         }
         out.push('\n');

--- a/src/plugins/tui/components/list/mod.rs
+++ b/src/plugins/tui/components/list/mod.rs
@@ -52,10 +52,8 @@ impl StyledList {
 
         if self.markable {
             selected.extend(self.marked.iter().copied());
-        } else {
-            if let Some(index) = self.state.selected() {
-                selected.push(index);
-            }
+        } else if let Some(index) = self.state.selected() {
+            selected.push(index);
         }
 
         if selected.is_empty() {

--- a/src/plugins/tui/components/log_viewer/mod.rs
+++ b/src/plugins/tui/components/log_viewer/mod.rs
@@ -63,9 +63,9 @@ impl LogViewer {
         };
 
         let local_time = Local::now().format("[%H:%M:%S]").to_string();
-        let item = ListItem::new(Line::from(vec![
+        ListItem::new(Line::from(vec![
             Span::styled(
-                format!("{local_time}"),
+                local_time.to_string(),
                 Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
             ),
             Span::styled(
@@ -80,9 +80,7 @@ impl LogViewer {
                     })
                     .add_modifier(Modifier::BOLD),
             ),
-        ]));
-
-        item
+        ]))
     }
 }
 

--- a/src/plugins/tui/components/modal/mod.rs
+++ b/src/plugins/tui/components/modal/mod.rs
@@ -136,12 +136,12 @@ impl EventHandler<KeyEvent> for Modal {
     async fn callback(&mut self, event: KeyEvent) -> anyhow::Result<Vec<Echo>> {
         let mut output = vec![];
 
-        if event.code == KeyCode::Enter {
-            if let Some(selected) = self.list.selected() {
-                output.push(Echo::Choose(selected));
-                self.close();
-                self.emit_up(events::Close).await?;
-            }
+        if event.code == KeyCode::Enter
+            && let Some(selected) = self.list.selected()
+        {
+            output.push(Echo::Choose(selected));
+            self.close();
+            self.emit_up(events::Close).await?;
         }
 
         self.list.emit_down(event).await?;

--- a/src/plugins/tui/events/mod.rs
+++ b/src/plugins/tui/events/mod.rs
@@ -38,7 +38,7 @@ macro_rules! events_runtime {
                 $(
                     <Self as EventHandler<$LE>>::register_event(
                         self,
-                        crate::plugins::tui::events::traits::EmitType::Local
+                        $crate::plugins::tui::events::traits::EmitType::Local
                     ).await?;
                 )*
 
@@ -46,7 +46,7 @@ macro_rules! events_runtime {
                 $(
                     <Self as EventHandler<$GE>>::register_event(
                         self,
-                        crate::plugins::tui::events::traits::EmitType::Parent
+                        $crate::plugins::tui::events::traits::EmitType::Parent
                     ).await?;
                 )*
 
@@ -74,7 +74,7 @@ macro_rules! events_runtime {
                     output.extend(
                         <Self as EventHandler<$LE>>::try_update(
                             self,
-                            crate::plugins::tui::events::traits::EmitType::Local
+                            $crate::plugins::tui::events::traits::EmitType::Local
                         ).await?
                     );
                 )*
@@ -83,7 +83,7 @@ macro_rules! events_runtime {
                     output.extend(
                         <Self as EventHandler<$GE>>::try_update(
                             self,
-                            crate::plugins::tui::events::traits::EmitType::Parent
+                            $crate::plugins::tui::events::traits::EmitType::Parent
                         ).await?
                     );
                 )*

--- a/src/plugins/wow/wotlk/realm/init/auth_challenge.rs
+++ b/src/plugins/wow/wotlk/realm/init/auth_challenge.rs
@@ -128,7 +128,7 @@ impl AddonInfo {
             4 // u32: number of addons at the start of the buffer
                 + addons.iter()
                 .map(|a|
-                         a.name.as_bytes().len() // addon name bytes
+                         a.name.len() // addon name bytes
                              + 1 // C-string NUL terminator after the name
                              + 1 // flags: u8
                              + 4 // modulus_crc: u32 (little-endian)

--- a/src/plugins/wow/wotlk/realm/init/player_login.rs
+++ b/src/plugins/wow/wotlk/realm/init/player_login.rs
@@ -31,7 +31,7 @@ impl PacketHandler for Handler {
         let guid = *self.guid.lock().unwrap();
         let mut guard = self.is_logged_in.lock().unwrap();
 
-        if *guard == false && guid > 0 {
+        if !*guard && guid > 0 {
             output.extend(vec![
                 HandlerOutput::Packets(vec![
                     Outgoing { guid }.pack()?

--- a/src/plugins/wow/wotlk/realm/init/select_character.rs
+++ b/src/plugins/wow/wotlk/realm/init/select_character.rs
@@ -105,7 +105,7 @@ impl PacketHandler for Handler {
             ]))
         } else {
             let re = Regex::new(&autoselect.character_name)?;
-            if let Some(character) = characters.into_iter().find(|item| re.is_match(&item.name.as_ref()))
+            if let Some(character) = characters.into_iter().find(|item| re.is_match(item.name.as_ref()))
             {
                 let Character { name, guid, .. } = character;
                 *self.guid.lock().unwrap() = guid;

--- a/src/plugins/wow/wotlk/realm/mod.rs
+++ b/src/plugins/wow/wotlk/realm/mod.rs
@@ -42,6 +42,7 @@ impl NetworkPlugin for RealmPlugin {
 #[derive(Default)]
 pub struct Processors;
 impl ProcessorPlugin for Processors {
+    #[allow(clippy::default_constructed_unit_structs)]
     fn get_processors(&self) -> Vec<Box<dyn Processor>> {
         vec![
             Box::new(InitProcessor::default()),

--- a/src/plugins/wow/wotlk/realm/network.rs
+++ b/src/plugins/wow/wotlk/realm/network.rs
@@ -8,18 +8,10 @@ use crate::plugins::wow::wotlk::realm::rc4::{Decryptor, Encryptor};
 
 const OPCODE_SIZE: usize = 2;
 
+#[derive(Default)]
 pub struct PacketReader {
     decryptor: Option<Decryptor>,
     is_decrypted: bool,
-}
-
-impl Default for PacketReader {
-    fn default() -> Self {
-        Self {
-            decryptor: None,
-            is_decrypted: false,
-        }
-    }
 }
 
 impl BytesRead for PacketReader {
@@ -32,23 +24,23 @@ impl BytesRead for PacketReader {
 
         let mut is_long_packet = false;
 
-        if !self.is_decrypted {
-            if let Some(decryptor) = self.decryptor.as_mut() {
-                decryptor.decrypt(&mut header[..1]);
-                is_long_packet = (header[0] & 0x80) != 0;
-                if is_long_packet {
-                    if buffer.len() < 5 {
-                        anyhow::bail!("Incomplete header (long)... continue reading.");
-                    }
-
-                    let extra_byte = buffer[4];
-                    header.push(extra_byte);
+        if !self.is_decrypted
+            && let Some(decryptor) = self.decryptor.as_mut()
+        {
+            decryptor.decrypt(&mut header[..1]);
+            is_long_packet = (header[0] & 0x80) != 0;
+            if is_long_packet {
+                if buffer.len() < 5 {
+                    anyhow::bail!("Incomplete header (long)... continue reading.");
                 }
-                decryptor.decrypt(&mut header[1..]);
 
-                buffer[..header.len()].copy_from_slice(&header);
-                self.is_decrypted = true;
+                let extra_byte = buffer[4];
+                header.push(extra_byte);
             }
+            decryptor.decrypt(&mut header[1..]);
+
+            buffer[..header.len()].copy_from_slice(&header);
+            self.is_decrypted = true;
         }
 
         let mut header_reader = Cursor::new(&header);
@@ -66,10 +58,10 @@ impl BytesRead for PacketReader {
         reader.read_exact(&mut body)?;
 
         // we set the decryptor once the first packet has been read
-        if self.decryptor.is_none() {
-            if let Some(secret) = context.get::<Secret>() {
-                self.decryptor = Some(Decryptor::new(&secret.0.to_vec()));
-            }
+        if self.decryptor.is_none()
+            && let Some(secret) = context.get::<Secret>()
+        {
+            self.decryptor = Some(Decryptor::new(&secret.0.to_vec()));
         }
 
         self.is_decrypted = false;
@@ -109,10 +101,10 @@ impl Serializer for PacketSerializer {
 
         buffer.extend_from_slice(&packet.content.body);
 
-        if self.encryptor.is_none() {
-            if let Some(secret) = context.get::<Secret>() {
-                self.encryptor = Some(Encryptor::new(&secret.0.to_vec()));
-            }
+        if self.encryptor.is_none()
+            && let Some(secret) = context.get::<Secret>()
+        {
+            self.encryptor = Some(Encryptor::new(&secret.0.to_vec()));
         }
 
         Ok(buffer)

--- a/src/plugins/wow/wotlk/realm/object/monster_move.rs
+++ b/src/plugins/wow/wotlk/realm/object/monster_move.rs
@@ -43,7 +43,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| f.contains(SplineFlags::ANIMATION))
+                .is_some_and(|f| f.contains(SplineFlags::ANIMATION))
         ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     animation_id: Option<u8>,
@@ -52,7 +52,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| f.contains(SplineFlags::ANIMATION))
+                .is_some_and(|f| f.contains(SplineFlags::ANIMATION))
         ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     parabolic_start_time: Option<i32>,
@@ -65,7 +65,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| f.contains(SplineFlags::PARABOLIC))
+                .is_some_and(|f| f.contains(SplineFlags::PARABOLIC))
         ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     vertical_acceleration: Option<f32>,
@@ -74,7 +74,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| f.contains(SplineFlags::PARABOLIC))
+                .is_some_and(|f| f.contains(SplineFlags::PARABOLIC))
         ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     animation_start_time: Option<i32>,
@@ -85,7 +85,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| !f.is_catmull_rom())
+                .is_some_and(|f| !f.is_catmull_rom())
         ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     destination_point: Option<Point3D>,
@@ -94,7 +94,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| !f.is_catmull_rom())
+                .is_some_and(|f| !f.is_catmull_rom())
             && path_size > 1
         ))]
     // it seems the "count" attr is evaluated independently of "if" attr
@@ -107,7 +107,7 @@ struct Incoming {
             move_type != MonsterMoveType::Stop
             && spline_flags
                 .as_ref()
-                .map_or(false, |f| f.is_catmull_rom())
+                .is_some_and(|f| f.is_catmull_rom())
         ))]
     #[br(count = path_size)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/plugins/wow/wotlk/realm/object/types/packed_guid.rs
+++ b/src/plugins/wow/wotlk/realm/object/types/packed_guid.rs
@@ -83,7 +83,7 @@ impl BinWrite for PackedGuid {
 
     fn write<W: Write>(&self, writer: &mut W) -> BinResult<()> {
         let mut guid = self.0;
-        let mut packed_guid = vec![0u8; 9];
+        let mut packed_guid = [0u8; 9];
         let mut size = 1;
         let mut index = 0;
 
@@ -107,7 +107,7 @@ impl BinWrite for PackedGuid {
         _: Self::Args<'_>,
     ) -> BinResult<()> {
         let mut guid = self.0;
-        let mut packed_guid = vec![0u8; 9];
+        let mut packed_guid = [0u8; 9];
         let mut size = 1;
         let mut index = 0;
 

--- a/src/plugins/wow/wotlk/realm/object/types/update_data.rs
+++ b/src/plugins/wow/wotlk/realm/object/types/update_data.rs
@@ -417,7 +417,7 @@ impl BinWrite for UpdateData {
         let (update_fields, values_limit) = self.collect_update_fields();
 
         // blocks_amount
-        let blocks_amount: u8 = ((values_limit + 31) / 32) as u8;
+        let blocks_amount: u8 = values_limit.div_ceil(32) as u8;
         u8::write_options(&blocks_amount, writer, endian, ())?;
 
         // mask

--- a/src/plugins/wow/wotlk/realm/object/types/update_fields.rs
+++ b/src/plugins/wow/wotlk/realm/object/types/update_fields.rs
@@ -318,14 +318,13 @@ macro_rules! fields {
 
                     let types = match field_type {
                         "Custom" => {
-                            #[allow(unused_mut)]
-                            let mut types = Vec::new();
-                            $(
+                            vec![
                                 $(
-                                    types.push(stringify!($custom_types).to_string());
-                                )*
-                            )?
-                            types
+                                    $(
+                                        stringify!($custom_types).to_string(),
+                                    )*
+                                )?
+                            ]
                         }
                         _ => vec![field_type.to_string()],
                     };

--- a/src/plugins/wow/wotlk/realm/object/update_object.rs
+++ b/src/plugins/wow/wotlk/realm/object/update_object.rs
@@ -53,15 +53,12 @@ impl PacketHandler for Handler {
             let option = guard.get::<HashMap<PackedGuid, Object>>();
             if let Some(objects) = option {
                 for block in incoming.blocks.iter_mut() {
-                    if let BlockType::Values = block.block_type {
-                        if let Some(guid) = block.guid.as_ref() {
-                            if let Some(object) = objects.get(guid) {
-                                if let Some(update_data) = block.update_data.as_mut() {
-                                    sanitize_update_data(update_data, object.object_type_mask);
-                                }
-                            }
-                        }
-
+                    if let BlockType::Values = block.block_type
+                        && let Some(guid) = block.guid.as_ref()
+                        && let Some(object) = objects.get(guid)
+                        && let Some(update_data) = block.update_data.as_mut()
+                    {
+                        sanitize_update_data(update_data, object.object_type_mask);
                     }
                 }
             }
@@ -357,6 +354,7 @@ impl TryFrom<Block> for Object {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum ObjectBuildError {
     MissingGuid,
     MissingObjectTypeId,


### PR DESCRIPTION
### Motivation
- Clean up numerous Clippy lints and improve control-flow clarity across the client runtime and plugins. 
- Simplify nested conditionals and remove unnecessary temporaries to make intent clearer and reduce boilerplate. 
- Ensure binrw writer helpers and packet metadata extraction match expected signatures and avoid incorrect bindings. 
- Improve small performance / allocation hotspots (arrays vs vecs, avoid extra allocations) in hot paths.

### Description
- Refactored nested `if let` chains into `let`-chain conditionals and replaced `match` used for single-pattern destructuring with `if let` where appropriate, e.g. `src/client/macros/packet/src/lib.rs`, `src/client/plugin.rs`, `src/plugins/wow/wotlk/realm/network.rs` and several TUI components. 
- Simplified request/output handling and ordering logic, replaced `requests.drain(..).collect()` with `std::mem::take(requests)` and returned metadata directly from `extract_metadata`, in `src/client/plugin.rs` and `src/client/packet/mod.rs`. 
- Restored binrw writer signatures to match expected function types by using `&String` and adding `#[allow(clippy::ptr_arg)]` to `reversed` and `just_bytes` in `src/client/packet/helpers.rs`. 
- Miscellaneous clippy-driven fixes: use `div_ceil()` for ceil division, replace `vec![0u8;9]` with `[0u8;9]`, derive `Default` where possible, switch to calling `.to_string()` vs `format!`, use `$crate` in macros, and simplify other small patterns across TUI and WoW realm modules (multiple files under `src/plugins/*`).

### Testing
- Ran `cargo clippy` during development and after changes; clippy completed successfully with no compile errors (command: `cargo clippy`).
- Final `cargo clippy` run finished successfully (no errors) and reduced the number of warnings; the repository builds under the `dev` profile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9f2bcd3c832b92a429d6e81da663)