### PR TITLE
feat: TE-1 - added replay plugin to parse World.log files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacli"
-version = "15.0.0"
+version = "15.1.0"
 edition = "2024"
 authors = ["Sergio Ivanuzzo <sergio.ivanuzzo@gmail.com>"]
 description = "Framework for building extensible network protocol clients via modular plugins."
@@ -44,6 +44,8 @@ flate2 = { version = "1.0.24", optional = true }
 futures = "0.3.31"
 hmac-sha = { version = "0.6.1", optional = true }
 inventory = "0.3"
+memchr = { version = "2.7.4", optional = true }
+memmap2 = { version = "0.9.5", optional = true }
 meta-packet = "0.1.0"
 num-bigint = { version = "0.4.6", optional = true }
 num_enum = "0.7.4"
@@ -67,3 +69,4 @@ default-dbg = ["wow-wotlk", "dbg-ui"]
 tui = ["crossterm", "ratatui", "async-event-emitter"]
 dbg-ui = ["colored"]
 wow-wotlk = ["bitflags", "flate2", "sha-1", "hmac-sha", "rand", "num-bigint"]
+replay = ["memmap2", "memchr"]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,12 +41,25 @@ cfg_if! {
         use crate::plugins::wow::wotlk::{login, realm};
 
         // network plugins
+        #[cfg(not(feature = "replay"))]
         register_plugin!(login::LoginPlugin, dyn NetworkPlugin);
+        #[cfg(feature = "replay")]
+        register_plugin!(OutgoingPolicy<realm::RealmPlugin, false>, dyn NetworkPlugin);
+
+        #[cfg(not(feature = "replay"))]
         register_plugin!(realm::RealmPlugin, dyn NetworkPlugin);
 
         // processor plugins
+        #[cfg(not(feature = "replay"))]
         register_plugin!(login::Processors, dyn ProcessorPlugin);
         register_plugin!(realm::Processors, dyn ProcessorPlugin);
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "replay")] {
+        use crate::plugins::replay::Replay;
+        register_plugin!(Replay, dyn CorePlugin);
     }
 }
 
@@ -235,8 +248,9 @@ impl Client {
 
         println!("[OK] Build features");
         println!("  - tui        : {}", cfg!(feature = "tui"));
-        println!("  - dbg-ui    : {}", cfg!(feature = "dbg-ui"));
-        println!("  - wow-wotlk : {}", cfg!(feature = "wow-wotlk"));
+        println!("  - dbg-ui     : {}", cfg!(feature = "dbg-ui"));
+        println!("  - wow-wotlk  : {}", cfg!(feature = "wow-wotlk"));
+        println!("  - replay     : {}", cfg!(feature = "replay"));
 
         let snapshot = Client::snapshot_plugins();
 

--- a/src/client/plugin.rs
+++ b/src/client/plugin.rs
@@ -427,15 +427,17 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
         broadcast_tx: async_broadcast::Sender<OrderedOutput>,
         local_cancel: &CancellationToken,
     ) -> anyhow::Result<()> {
-        broadcast_tx.broadcast(OrderedOutput::new(self.label(), outputs.clone())).await?;
+        if self.enabled_outgoing() {
+            broadcast_tx.broadcast(OrderedOutput::new(self.label(), outputs.clone())).await?;
 
-        for output in &*outputs {
-            if let HandlerOutput::Packets(packets) = output {
-                with_cancel(
-                    &format!("{}-connection, handle_outputs", self.label()),
-                    local_cancel,
-                    packet_tx.send(packets.clone()).map_err(|e| anyhow::anyhow!(e.to_string())),
-                ).await?;
+            for output in &*outputs {
+                if let HandlerOutput::Packets(packets) = output {
+                    with_cancel(
+                        &format!("{}-connection, handle_outputs", self.label()),
+                        local_cancel,
+                        packet_tx.send(packets.clone()).map_err(|e| anyhow::anyhow!(e.to_string())),
+                    ).await?;
+                }
             }
         }
 
@@ -487,6 +489,54 @@ pub trait NetworkPlugin: Send + Sync + Any where Self: 'static {
     fn protocol(&self) -> Protocol;
     fn remote_addr(&self) -> anyhow::Result<Option<String>> {
         Ok(None)
+    }
+    fn enabled_outgoing(&self) -> bool {
+        true
+    }
+}
+
+pub struct OutgoingPolicy<T, const ENABLED: bool>(pub T);
+impl<T: Default, const ENABLED: bool> Default for OutgoingPolicy<T, ENABLED> {
+    fn default() -> Self {
+        Self(T::default())
+    }
+}
+
+#[async_trait]
+impl<T, const ENABLED: bool> NetworkPlugin for OutgoingPolicy<T, ENABLED>
+where
+    T: NetworkPlugin + Send + Sync + 'static,
+{
+    fn get_builders(&self) -> Vec<Box<dyn OutputBuilder>> {
+        self.0.get_builders()
+    }
+
+    fn get_reader(&self) -> Box<dyn BytesRead> {
+        self.0.get_reader()
+    }
+
+    fn get_serializer(&self) -> Box<dyn Serializer> {
+        self.0.get_serializer()
+    }
+
+    fn get_processors(&self) -> Vec<Box<dyn Processor>> {
+        self.0.get_processors()
+    }
+
+    fn label(&self) -> ServerLabel {
+        self.0.label()
+    }
+
+    fn protocol(&self) -> Protocol {
+        self.0.protocol()
+    }
+
+    fn remote_addr(&self) -> anyhow::Result<Option<String>> {
+        self.0.remote_addr()
+    }
+
+    fn enabled_outgoing(&self) -> bool {
+        ENABLED
     }
 }
 

--- a/src/client/types.rs
+++ b/src/client/types.rs
@@ -143,11 +143,11 @@ impl OrderedReceiver {
                 self.next = self.buffer.keys().next().copied();
             }
 
-            if let Some(next) = self.next
-                && let Some(entry) = self.buffer.remove(&next)
-            {
-                self.next = Some(next + 1);
-                return Ok(entry);
+            if let Some(next) = self.next {
+                if let Some(entry) = self.buffer.remove(&next) {
+                    self.next = Some(next + 1);
+                    return Ok(entry);
+                }
             }
 
             // soft-fail protection

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,6 +6,9 @@
 //! - `core` — Core system plugin (request handling, echo dispatch, shutdown wiring)
 //! - `tui` — Terminal UI frontend (feature: `tui`)
 //! - `dbg_ui` — Debug UI frontend (feature: `dbg-ui`)
+//! - `replay` — Offline packet replay plugin.
+//!   Replays packets from TrinityCore/MaNGOS-style `World.log` files
+//!   through the normal processing pipeline.
 
 pub mod wow;
 #[cfg(feature = "tui")]
@@ -13,3 +16,5 @@ pub mod tui;
 pub mod core;
 #[cfg(feature = "dbg-ui")]
 pub mod dbg_ui;
+#[cfg(feature = "replay")]
+pub mod replay;

--- a/src/plugins/replay/mod.rs
+++ b/src/plugins/replay/mod.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "wow-wotlk")]
+mod parser;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_broadcast::Receiver;
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::Sender;
+use tokio::sync::RwLock;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::client::prelude::*;
+
+const PLUGIN_LABEL: &str = crate::plugins::wow::wotlk::realm::PLUGIN_LABEL;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReplayCfg {
+    pub world_log_path: String,
+    pub opcodes: Vec<String>,
+    pub dedup: bool,
+    pub realtime: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub replay: Option<ReplayCfg>,
+}
+
+#[derive(Default)]
+pub struct Replay;
+impl Replay {
+    async fn handle_connection(
+        mut stream: TcpStream,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let config: Config = ConfigParser::parse_from_file("replay/replay.toml")?;
+        let replay = config.replay.ok_or_else(|| anyhow::anyhow!("Missing [replay]"))?;
+
+        let mut reader = parser::WorldLogReader::open(
+            &replay.world_log_path,
+            &replay.opcodes,
+            replay.dedup
+        )?;
+
+        let mut first_log_timestamp: Option<i64> = None;
+        let replay_start = Instant::now();
+
+        loop {
+            if shutdown.is_cancelled() {
+                break;
+            }
+
+            let Some(packet_data) = reader.next_packet() else {
+                break;
+            };
+
+            if replay.realtime {
+                if let Some(ts) = packet_data.timestamp {
+                    let base = first_log_timestamp.get_or_insert(ts);
+                    let delta = ts.saturating_sub(*base) as u64;
+                    let target = replay_start + Duration::from_secs(delta);
+
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.cancelled() => break,
+                        _ = tokio::time::sleep_until(target) => {}
+                    }
+                }
+            } else {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+
+            let opcode = packet_data.opcode;
+            let body = packet_data.payload;
+
+            let size = (2 + body.len()) as u16;
+
+            let mut buffer = Vec::with_capacity(2 + size as usize);
+            buffer.extend_from_slice(&size.to_be_bytes());
+            buffer.extend_from_slice(&opcode.to_le_bytes());
+            buffer.extend_from_slice(&body);
+
+            tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                result = stream.write_all(&buffer) => {
+                    result?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+}
+
+impl CorePlugin for Replay {
+    fn get_tasks(
+        &self,
+        _broadcast_rx: Receiver<OrderedOutput>,
+        echo_senders: Arc<HashMap<ServerLabel, Sender<Echo>>>,
+        shutdown: CancellationToken,
+        _: Arc<RwLock<CtxMap>>,
+    ) -> anyhow::Result<Vec<Task>> {
+        Ok(vec![
+            tokio::spawn(async move {
+                let listener = TcpListener::bind("127.0.0.1:0").await?;
+                let local_addr = listener.local_addr()?;
+
+                if let Some(sender) = echo_senders.get(PLUGIN_LABEL) {
+                    sender.send(Echo::Connect(local_addr.to_string())).await?;
+                } else {
+                    anyhow::bail!("Echo sender for {PLUGIN_LABEL} not found");
+                }
+
+                let (stream, _) = tokio::select! {
+                    biased;
+
+                    _ = shutdown.cancelled() => {
+                        return Ok(());
+                    }
+
+                    result = listener.accept() => {
+                        result?
+                    }
+                };
+
+                Replay::handle_connection(stream, shutdown.clone()).await?;
+
+                Ok(())
+            })
+        ])
+    }
+}

--- a/src/plugins/replay/parser.rs
+++ b/src/plugins/replay/parser.rs
@@ -1,0 +1,244 @@
+use std::collections::HashSet;
+use std::fs::File;
+
+use anyhow::Result;
+use chrono::{NaiveDateTime, TimeZone, Utc};
+use memchr::memchr;
+use memchr::memmem::find;
+use memmap2::Mmap;
+
+pub struct WorldLogReader {
+    mmap: Mmap,
+    offset: usize,
+    opcode_filter: Vec<Vec<u8>>,
+    dedup_enabled: bool,
+    payload_buffer: Vec<u8>,
+    current_timestamp: Option<i64>,
+    seen_in_second: HashSet<u64>,
+}
+
+pub struct LogPacket {
+    pub timestamp: Option<i64>,
+    pub opcode: u16,
+    pub opcode_name: String,
+    pub payload: Vec<u8>,
+}
+
+impl WorldLogReader {
+    pub fn open(path: &str, opcode_filter: &[String], dedup_enabled: bool) -> Result<Self> {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+
+        Ok(Self {
+            mmap,
+            offset: 0,
+            opcode_filter: opcode_filter.iter().map(|opcode| opcode.as_bytes().to_vec()).collect(),
+            dedup_enabled,
+            payload_buffer: Vec::new(),
+            current_timestamp: None,
+            seen_in_second: HashSet::new(),
+        })
+    }
+
+    pub fn next_packet(&mut self) -> Option<LogPacket> {
+        loop {
+            if self.offset >= self.mmap.len() {
+                return None;
+            }
+
+            let entry_start_offset = self.offset;
+            let next_entry_start_offset =
+                find_next_entry_start(&self.mmap, entry_start_offset + 1).unwrap_or(self.mmap.len());
+
+            let block = &self.mmap[entry_start_offset..next_entry_start_offset];
+
+            let (opcode_name_bytes, opcode_code) = match Self::extract_opcode(block) {
+                Some(value) => value,
+                None => {
+                    self.offset = next_entry_start_offset;
+                    continue;
+                }
+            };
+
+            if !self.opcode_filter.is_empty()
+                && !self
+                .opcode_filter
+                .iter()
+                .any(|filter| filter.as_slice() == opcode_name_bytes)
+            {
+                self.offset = next_entry_start_offset;
+                continue;
+            }
+
+            if !Self::extract_bytes(block, &mut self.payload_buffer) {
+                self.offset = next_entry_start_offset;
+                continue;
+            }
+
+            let timestamp = Self::extract_timestamp(block);
+
+            if self.dedup_enabled {
+                let should_keep = match timestamp {
+                    Some(ts) => {
+                        if self.current_timestamp != Some(ts) {
+                            self.current_timestamp = Some(ts);
+                            self.seen_in_second.clear();
+                        }
+
+                        let signature = dedup_signature_fnv1a(ts, opcode_code, &self.payload_buffer);
+                        self.seen_in_second.insert(signature)
+                    }
+                    None => true,
+                };
+
+                if !should_keep {
+                    self.offset = next_entry_start_offset;
+                    continue;
+                }
+            }
+
+            self.offset = next_entry_start_offset;
+
+            return Some(LogPacket {
+                timestamp,
+                opcode: opcode_code,
+                opcode_name: String::from_utf8_lossy(opcode_name_bytes).into_owned(),
+                payload: std::mem::take(&mut self.payload_buffer),
+            });
+        }
+    }
+
+    #[inline]
+    fn hex_to_bytes(input: &[u8], out: &mut Vec<u8>) -> bool {
+        out.clear();
+
+        let mut high_nibble: u8 = 0;
+        let mut have_high: bool = false;
+
+        for &byte in input {
+            let value = match byte {
+                b'0'..=b'9' => byte - b'0',
+                b'a'..=b'f' => byte - b'a' + 10,
+                b'A'..=b'F' => byte - b'A' + 10,
+                b' ' | b'\n' | b'\r' | b'\t' => continue,
+                _ => return false,
+            };
+
+            if have_high {
+                out.push((high_nibble << 4) | value);
+                have_high = false;
+            } else {
+                high_nibble = value;
+                have_high = true;
+            }
+        }
+
+        !have_high
+    }
+
+    #[inline]
+    fn extract_opcode(block: &[u8]) -> Option<(&[u8], u16)> {
+        const PREFIX: &[u8] = b"OPCODE: ";
+
+        let start = find(block, PREFIX)?;
+        let rest = &block[start + PREFIX.len()..];
+
+        let open_paren = find(rest, b" (")?;
+        let opcode_name = &rest[..open_paren];
+
+        let after_paren = &rest[open_paren + 2..];
+        let close_paren = memchr(b')', after_paren)?;
+
+        let hex_part = &after_paren[..close_paren];
+        if !hex_part.starts_with(b"0x") {
+            return None;
+        }
+
+        let hex_digits = std::str::from_utf8(&hex_part[2..]).ok()?;
+        let opcode_code = u16::from_str_radix(hex_digits, 16).ok()?;
+
+        Some((opcode_name, opcode_code))
+    }
+
+    #[inline]
+    fn extract_bytes(block: &[u8], out: &mut Vec<u8>) -> bool {
+        const DATA_LF: &[u8] = b"DATA:\n";
+        const DATA_CRLF: &[u8] = b"DATA:\r\n";
+
+        if let Some(pos) = find(block, DATA_LF) {
+            let payload = &block[pos + DATA_LF.len()..];
+            return Self::hex_to_bytes(payload, out);
+        }
+
+        if let Some(pos) = find(block, DATA_CRLF) {
+            let payload = &block[pos + DATA_CRLF.len()..];
+            return Self::hex_to_bytes(payload, out);
+        }
+
+        false
+    }
+
+    #[inline]
+    fn extract_timestamp(block: &[u8]) -> Option<i64> {
+        let mut start = 0;
+        while start < block.len() && matches!(block[start], b'\n' | b'\r') {
+            start += 1;
+        }
+
+        let trimmed_block = &block[start..];
+        let newline_pos = memchr(b'\n', trimmed_block)?;
+        let mut ts_bytes = &trimmed_block[..newline_pos];
+
+        while ts_bytes.last().is_some_and(|b| *b == b'\r' || *b == b' ' || *b == b'\t') {
+            ts_bytes = &ts_bytes[..ts_bytes.len() - 1];
+        }
+
+        let ts_str = std::str::from_utf8(ts_bytes).ok()?;
+        let naive = NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%d %H:%M:%S").ok()?;
+
+        Some(Utc.from_utc_datetime(&naive).timestamp())
+    }
+}
+
+#[inline]
+fn find_next_entry_start(haystack: &[u8], search_from: usize) -> Option<usize> {
+    let slice = &haystack[search_from..];
+
+    for i in 0..slice.len().saturating_sub(19) {
+        if slice[i].is_ascii_digit()
+            && &slice[i+4..i+5] == b"-"
+            && &slice[i+7..i+8] == b"-"
+            && &slice[i+10..i+11] == b" "
+            && &slice[i+13..i+14] == b":"
+            && &slice[i+16..i+17] == b":"
+        {
+            return Some(search_from + i);
+        }
+    }
+    None
+}
+
+#[inline]
+fn dedup_signature_fnv1a(timestamp: i64, opcode_code: u16, payload: &[u8]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 14695981039346656037;
+    const FNV_PRIME: u64 = 1099511628211;
+
+    let mut hash: u64 = FNV_OFFSET_BASIS;
+
+    for byte in timestamp.to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    for byte in opcode_code.to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    for &byte in payload {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    hash
+}

--- a/src/plugins/replay/replay.toml
+++ b/src/plugins/replay/replay.toml
@@ -1,0 +1,27 @@
+[replay]
+# Path to World.log (MaNGOS / TrinityCore-style server log)
+world_log_path = "World.log"
+# List of opcode names to replay.
+# Example:
+# opcodes = ["SMSG_MESSAGECHAT", "SMSG_UPDATE_OBJECT"]
+#
+# If empty (opcodes = []), ALL packets found in the log will be replayed.
+opcodes = []
+# Remove broadcast duplicates.
+#
+# When enabled, identical packets (same opcode + payload)
+# that appear multiple times within the same log second
+# are replayed only once.
+#
+# This is useful for broadcast packets that are logged
+# once per connected client (e.g. movement, chat, world updates),
+# but should be replayed as a single logical event.
+dedup = true
+# Replay timing mode:
+#
+# false → packets are sent as fast as possible (with minimal yielding),
+#         ignoring original timestamps in the log.
+#
+# true  → packets are replayed according to their original timestamps,
+#         preserving real-time delays between packets.
+realtime = false

--- a/src/plugins/wow/wotlk/realm/network.rs
+++ b/src/plugins/wow/wotlk/realm/network.rs
@@ -21,29 +21,32 @@ impl BytesRead for PacketReader {
         }
 
         let mut header = buffer[..4].to_vec();
-
         let mut is_long_packet = false;
 
-        if !self.is_decrypted
-            && let Some(decryptor) = self.decryptor.as_mut()
-        {
-            decryptor.decrypt(&mut header[..1]);
-            is_long_packet = (header[0] & 0x80) != 0;
-            if is_long_packet {
-                if buffer.len() < 5 {
-                    anyhow::bail!("Incomplete header (long)... continue reading.");
+        if !self.is_decrypted {
+            if let Some(decryptor) = self.decryptor.as_mut() {
+                decryptor.decrypt(&mut header[..1]);
+
+                is_long_packet = (header[0] & 0x80) != 0;
+
+                if is_long_packet {
+                    if buffer.len() < 5 {
+                        anyhow::bail!("Incomplete header (long)... continue reading.");
+                    }
+
+                    let extra_byte = buffer[4];
+                    header.push(extra_byte);
                 }
 
-                let extra_byte = buffer[4];
-                header.push(extra_byte);
-            }
-            decryptor.decrypt(&mut header[1..]);
+                decryptor.decrypt(&mut header[1..]);
 
-            buffer[..header.len()].copy_from_slice(&header);
-            self.is_decrypted = true;
+                buffer[..header.len()].copy_from_slice(&header);
+                self.is_decrypted = true;
+            }
         }
 
         let mut header_reader = Cursor::new(&header);
+
         let size = if is_long_packet {
             header_reader.read_u24::<BigEndian>()? as usize
         } else {
@@ -57,11 +60,10 @@ impl BytesRead for PacketReader {
         let mut body = vec![0u8; size];
         reader.read_exact(&mut body)?;
 
-        // we set the decryptor once the first packet has been read
-        if self.decryptor.is_none()
-            && let Some(secret) = context.get::<Secret>()
-        {
-            self.decryptor = Some(Decryptor::new(&secret.0.to_vec()));
+        if self.decryptor.is_none() {
+            if let Some(secret) = context.get::<Secret>() {
+                self.decryptor = Some(Decryptor::new(&secret.0.to_vec()));
+            }
         }
 
         self.is_decrypted = false;
@@ -69,7 +71,9 @@ impl BytesRead for PacketReader {
         let mut packet = Packet::default();
         packet.set_type(PacketType::Incoming);
         packet.set_opcode(PacketOpcode::U16(opcode));
-        packet.set_packet_name(Opcode::get_opcode_name(opcode as u32).unwrap_or_default());
+        packet.set_packet_name(
+            Opcode::get_opcode_name(opcode as u32).unwrap_or_default(),
+        );
         packet.set_packet_size(body.len() + header.len());
         packet.set_body(body);
 
@@ -101,10 +105,10 @@ impl Serializer for PacketSerializer {
 
         buffer.extend_from_slice(&packet.content.body);
 
-        if self.encryptor.is_none()
-            && let Some(secret) = context.get::<Secret>()
-        {
-            self.encryptor = Some(Encryptor::new(&secret.0.to_vec()));
+        if self.encryptor.is_none() {
+            if let Some(secret) = context.get::<Secret>() {
+                self.encryptor = Some(Encryptor::new(&secret.0.to_vec()));
+            }
         }
 
         Ok(buffer)


### PR DESCRIPTION
Also added an option to disable outgoing packets.

With the replay plugin, you can:
- filter only the required opcodes,
- display packets in real time or as fast as possible,
- toggle deduplication to prevent broadcasting duplicated packets (for example, chat messages that are duplicated for each online client).