### PR TITLE
logger: migrate enabled flag to bool and use constant for flush interval

### DIFF
--- a/src/plugins/wow/logger/logger.toml
+++ b/src/plugins/wow/logger/logger.toml
@@ -1,6 +1,6 @@
 logs_dir = "."
-# 0 = disabled (no files/no logging), 1 = enabled.
-enabled = 0
+# false = disabled (no files/no logging), true = enabled.
+enabled = false
 # Flush interval to disk in milliseconds. Useful for slower disks/HDDs: increase value to reduce I/O pressure, decrease for faster visibility in file (0 = only flush on rotation/shutdown).
 flush_interval_ms = 200
 # 0 = always write to one file; > 0 = rotate into fragments when size exceeds this value (MiB).

--- a/src/plugins/wow/logger/mod.rs
+++ b/src/plugins/wow/logger/mod.rs
@@ -24,18 +24,25 @@ use crate::plugins::wow::wotlk::realm;
 use crate::plugins::wow::wotlk::config::Config as WotlkConfig;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub logs_dir: String,
-    #[serde(default)]
-    pub enabled: u8,
-    #[serde(default = "default_flush_interval_ms")]
+    pub enabled: bool,
     pub flush_interval_ms: u64,
-    #[serde(default)]
     pub max_file_size: u64,
 }
 
-fn default_flush_interval_ms() -> u64 {
-    200
+const DEFAULT_FLUSH_INTERVAL_MS: u64 = 200;
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            logs_dir: String::new(),
+            enabled: false,
+            flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
+            max_file_size: 0,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -192,7 +199,7 @@ impl CorePlugin for Logger {
         _: Arc<RwLock<CtxMap>>,
     ) -> anyhow::Result<Vec<Task>> {
         let config: Config = ConfigParser::parse_from_file("wow/logger/logger.toml")?;
-        if config.enabled == 0 {
+        if !config.enabled {
             return Ok(vec![]);
         }
 
@@ -331,7 +338,7 @@ mod tests {
 
     use crate::client::ConfigParser;
     use crate::client::packet::{Packet, PacketOpcode, PacketType};
-    use super::{Config, Logger};
+    use super::{Config, Logger, DEFAULT_FLUSH_INTERVAL_MS};
 
     struct EnvGuard {
         key: &'static str,
@@ -455,8 +462,8 @@ character_name = "TestChar"
         )
             .expect("parse config");
 
-        assert_eq!(cfg.enabled, 0);
-        assert_eq!(cfg.flush_interval_ms, 200);
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.flush_interval_ms, DEFAULT_FLUSH_INTERVAL_MS);
         assert_eq!(cfg.max_file_size, 0);
     }
 }


### PR DESCRIPTION
### Motivation
- Make the logger configuration more idiomatic by using a boolean `enabled` flag instead of numeric `0/1` and provide sensible struct-level defaults. 
- Replace the small helper function for the default flush interval with a named constant to avoid trivial functions and centralize the default value.

### Description
- Changed `Config.enabled` from `u8` to `bool` and added `#[serde(default)]` on the `Config` struct so missing fields are filled from `Default` implementation (file: `src/plugins/wow/logger/mod.rs`).
- Removed `fn default_flush_interval_ms() -> u64` and introduced `const DEFAULT_FLUSH_INTERVAL_MS: u64 = 200`, and implemented `Default for Config` to provide default values for `logs_dir`, `enabled`, `flush_interval_ms`, and `max_file_size` (file: `src/plugins/wow/logger/mod.rs`).
- Replaced runtime check `if config.enabled == 0` with `if !config.enabled` to use the boolean guard (file: `src/plugins/wow/logger/mod.rs`).
- Updated example config `wow/logger/logger.toml` to use `enabled = false` and adjusted the comment accordingly (file: `src/plugins/wow/logger/logger.toml`).
- Updated unit test `parse_logger_config_default_max_file_size` to assert `!cfg.enabled` and that `cfg.flush_interval_ms == DEFAULT_FLUSH_INTERVAL_MS` (file: `src/plugins/wow/logger/mod.rs` tests).

### Testing
- Ran `cargo test parse_logger_config_default_max_file_size --features wow-wotlk` but the test run could not complete due to an environment network error when fetching crates.io (HTTP 403), so tests did not execute successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d4dc0654832b9340ee13adfc7859)