### PR TITLE
Resolve clippy `collapsible_if` findings in multiple modules

### DIFF
--- a/src/client/types.rs
+++ b/src/client/types.rs
@@ -137,11 +137,11 @@ impl OrderedReceiver {
                 self.next = self.buffer.keys().next().copied();
             }
 
-            if let Some(next) = self.next {
-                if let Some(entry) = self.buffer.remove(&next) {
-                    self.next = Some(next + 1);
-                    return Ok(entry);
-                }
+            if let Some(next) = self.next
+                && let Some(entry) = self.buffer.remove(&next)
+            {
+                self.next = Some(next + 1);
+                return Ok(entry);
             }
 
             // soft-fail protection

--- a/src/plugins/dbg_ui/mod.rs
+++ b/src/plugins/dbg_ui/mod.rs
@@ -84,25 +84,25 @@ impl CorePlugin for DbgUI {
                                         }
 
                                         loop {
-                                            if let Ok(Some(line)) = lines.next_line().await {
-                                                if let Ok(idx) = line.trim().parse::<usize>() {
-                                                    if let Some(chosen) = items.get(idx) {
-                                                        println!("You chose: {}", chosen);
+                                            if let Ok(Some(line)) = lines.next_line().await
+                                                && let Ok(idx) = line.trim().parse::<usize>()
+                                            {
+                                                if let Some(chosen) = items.get(idx) {
+                                                    println!("You chose: {}", chosen);
 
-                                                        let option = echo_senders.get(&label);
-                                                        if let Some(sender) = option {
-                                                            let _ = sender
-                                                                .send(Echo::Choose(vec![idx]))
-                                                                .await;
-                                                        }
-
-                                                        break;
-                                                    } else {
-                                                        println!(
-                                                            "{}",
-                                                            "Invalid index, try again".bright_red()
-                                                        );
+                                                    let option = echo_senders.get(&label);
+                                                    if let Some(sender) = option {
+                                                        let _ = sender
+                                                            .send(Echo::Choose(vec![idx]))
+                                                            .await;
                                                     }
+
+                                                    break;
+                                                } else {
+                                                    println!(
+                                                        "{}",
+                                                        "Invalid index, try again".bright_red()
+                                                    );
                                                 }
                                             }
                                         }

--- a/src/plugins/tui/components/json_navigator/mod.rs
+++ b/src/plugins/tui/components/json_navigator/mod.rs
@@ -287,21 +287,21 @@ impl EventHandler<KeyEvent> for JsonNavigator {
 
         match event.code {
             KeyCode::Up => {
-                if self.nav_active {
+                if self.nav_active && {
                     moved = self.cursor.step_backward().is_some();
-                    if !moved {
-                        self.json_scroll = self.json_scroll.saturating_sub(1);
-                        self.hex_scroll = self.hex_scroll.saturating_sub(1);
-                    }
+                    !moved
+                } {
+                    self.json_scroll = self.json_scroll.saturating_sub(1);
+                    self.hex_scroll = self.hex_scroll.saturating_sub(1);
                 }
             }
             KeyCode::Down => {
-                if self.nav_active {
+                if self.nav_active && {
                     moved = self.cursor.step_forward().is_some();
-                    if !moved {
-                        self.json_scroll = self.json_scroll.saturating_add(1);
-                        self.hex_scroll = self.hex_scroll.saturating_add(1);
-                    }
+                    !moved
+                } {
+                    self.json_scroll = self.json_scroll.saturating_add(1);
+                    self.hex_scroll = self.hex_scroll.saturating_add(1);
                 }
             }
             KeyCode::Left => {


### PR DESCRIPTION
### Motivation
- Address code-scanning warnings from clippy about collapsible nested `if`/`if let` patterns in input handling and buffered message retrieval to improve code clarity and satisfy lint rules.

### Description
- Refactored `JsonNavigator` Up/Down handlers to combine nested `if` checks into a single condition while preserving the `moved` flag and scroll behavior (`src/plugins/tui/components/json_navigator/mod.rs`).
- Collapsed sequential checks for reading and parsing a user input line into a chained `if let` to simplify the interactive choice flow (`src/plugins/dbg_ui/mod.rs`).
- Combined nested `if let` checks in `OrderedReceiver::recv` into a chained `if let` to simplify buffered entry retrieval (`src/client/types.rs`).

### Testing
- Ran `cargo fmt --all` and `cargo fmt --all -- --check` successfully with no formatting issues.
- Attempted `cargo clippy --all-targets --all-features -q`, but the run failed due to an environment network error when downloading `https://index.crates.io/config.json` (HTTP 403 via CONNECT tunnel), so clippy could not be fully validated.
- Verified local formatting and non-network validation steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b030424832bbcd0dfbe870a8034)